### PR TITLE
chore(release): v0.0.3 — autonomous asciinema capture + clip timing contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-06-08
+
+Added a professional, skill-driven asciinema + agg CLI recording path so
+terminal scenes can be captured autonomously — no user keyboard required.
+The prior Phase 2 path treated asciinema as a one-line user-side note;
+this release wires it as a first-class capture source on par with Chrome
+DevTools screenshots and screencast clips.
+
 ### Added
 
-- README "Updating" section documenting how to pull the latest skill version.
+- **Autonomous asciinema recording.** The skill drives `asciinema rec
+  --command "<cmd>"` itself via its Bash tool: PTY-isolated, env-scrubbed
+  (`env -i HOME=$HOME PATH=$PATH SHELL=/bin/bash PS1='$ '`), and bounded
+  by `timeout Ns` so runaway / non-terminating commands can't stall the
+  phase. The user never opens a terminal. `agg` then renders the cast to
+  MP4 in the same autonomous sequence.
+- `patterns/cli-terminal-capture.md` — end-to-end guide: when to use the
+  asciinema path vs. the authored-terminal fallback, install per OS,
+  autonomous recording sequence, edge cases (long-running commands,
+  piped input, secrets-without-leaking, PTY allocation fallback to
+  `script -qc`), agg theme→palette pairing, quality gate, troubleshooting.
+- `templates/scene-terminal-clip.html` — Layer-A clip-scene archetype that
+  wraps the agg-rendered MP4 in a macOS-style window for brand parity
+  with browser-mockup scenes. Animates the `.term-frame` wrapper only
+  (respects the no-`<video>`-dimension-tween rule).
+- `templates/storyboard.md` — new `Capture: terminal-clip` value plus
+  required `Command:` and `Record timeout:` fields so storyboards carry
+  the inputs the autonomous path needs.
+- README "Updating" section documenting how to pull the latest skill
+  version (carried over from Unreleased).
+
+### Changed
+
+- `SKILL.md` frontmatter — `description` broadened so Phase 2 reads as a
+  multi-source step ("Chrome DevTools screenshots + screencast clips,
+  asciinema terminal recording") instead of screenshots only;
+  `allowed-tools` gains `Bash(asciinema:*), Bash(agg:*),
+  Bash(timeout:*), Bash(ffprobe:*)`; prerequisites block prints an
+  actionable per-OS install hint when asciinema/agg are missing.
+- `workflows/phase-2-capture.md` — replaces the 3-line asciinema note
+  with the full autonomous record → render → verify sequence,
+  preconditions, and the edge-case matrix.
+- `README.md` prerequisites table — concrete install commands and a link
+  to the new pattern doc.
+- `patterns/INDEX.md` and `CLAUDE.md` — register the new pattern doc and
+  template so future editing sessions find them.
+
+### Unchanged (by design)
+
+- If `asciinema`/`agg` are missing, the skill silently falls back to the
+  authored-terminal scene (`templates/scene-terminal.html`). No install
+  prompts — the user is told once, then Phase 2 proceeds.
 
 ## [0.0.2] - 2026-06-04
 
@@ -107,6 +156,7 @@ Initial release of the hve-spielberg skill.
   earlier Pixabay integration.
 - README with install instructions and an MIT license.
 
-[Unreleased]: https://github.com/nebrass/hve-spielberg/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/nebrass/hve-spielberg/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/nebrass/hve-spielberg/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/nebrass/hve-spielberg/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/nebrass/hve-spielberg/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@ DevTools screenshots and screencast clips.
   midpoints, then read the PNGs) — the mechanical gates can't see wrong
   content; this is how the bare-`<video>` cross-route shipped unnoticed.
 
+### Security
+
+- **Subresource Integrity on the GSAP CDN tag.** Every `<script>` loading
+  `gsap@3.14.2` from jsDelivr (4 templates, the phase-3/phase-4 skeletons, and
+  all `example/` scenes) now carries `integrity="sha384-…" crossorigin="anonymous"`,
+  so a tampered CDN response is rejected by the browser instead of executing in
+  `preview`/render. `CLAUDE.md` documents the hash-recompute step required on any
+  future GSAP version bump.
+
 ### Unchanged (by design)
 
 - If `asciinema`/`agg` are missing, the skill silently falls back to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,47 @@ DevTools screenshots and screencast clips.
 - `patterns/INDEX.md` and `CLAUDE.md` — register the new pattern doc and
   template so future editing sessions find them.
 
+### Fixed
+
+- **Clip `<video>` timing contract.** Clip scenes previously used a bare
+  `<video>` and told authors *not* to add timing attributes. The runtime only
+  frame-syncs videos carrying `data-start`, so with 2+ clip scenes footage
+  cross-routed (one scene played another's footage, another played black)
+  while `lint`/`inspect`/`validate` all passed green. Both clip templates and
+  the phase-3/4 docs now mandate the explicit contract: `id` +
+  `data-start="0"` + `data-duration` + `data-media-start` +
+  `data-track-index="0"`. Also added to the central `## DON'Ts` list and as a
+  carve-out in `patterns/transition-catalog.md`.
+- **`Clip in/out` trim now lands in the scene** via `data-media-start`
+  (= storyboard `Clip in`). Previously the trim was silently ignored — the
+  video played from source `t=0` and desynced from Phase 5's clip-audio
+  extraction (`CIN`).
+- **Clips no longer blank during crossfades.** The inner video's
+  `data-duration` is the scene loader's full crossfade-extended window (per
+  `patterns/transition-catalog.md`), not the bare clip length — an
+  expired track goes `visibility:hidden` mid-crossfade otherwise.
+- **Phase 1 now surfaces `Capture: terminal-clip`** (with `Command:` /
+  `Record timeout:`) so new-mode storyboards can actually trigger the
+  autonomous asciinema path.
+- **asciinema record env keeps `LANG`** (`LANG="${LANG:-C.UTF-8}"` through
+  `env -i`) — asciinema 2.x aborts without a UTF-8 locale.
+- **agg no longer passes `--cols`/`--rows`** — it reads the size from the
+  cast header; the previous hardcoded `144×32` mismatched the recorded
+  `175×32` and wrapped/letterboxed wide output. The intermediate GIF now goes
+  to `$TMPDIR` instead of `public/clips/`, and the verify step reads
+  `nb_frames` from the header instead of a full `-count_frames` decode.
+- **`timeout` is feature-detected** (GNU coreutils; absent on stock macOS —
+  install hint now says `brew install asciinema agg coreutils`), and the
+  PTY-failure fallback documents both `script` syntaxes (GNU `-qc` vs
+  BSD/macOS positional). `allowed-tools` gains `Bash(script:*)` and
+  `mcp__chrome-devtools__emulate` (used for viewport + dark-mode emulation).
+- **Dark-mode MutationObserver guidance inverted to the working order** —
+  inject *after* `navigate_page` (navigation wipes the page's JS context;
+  hydration re-renders don't navigate, so the observer survives them).
+- **Mandatory hero-frame content check in Phase 4** (`inspect --at` scene
+  midpoints, then read the PNGs) — the mechanical gates can't see wrong
+  content; this is how the bare-`<video>` cross-route shipped unnoticed.
+
 ### Unchanged (by design)
 
 - If `asciinema`/`agg` are missing, the skill silently falls back to the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ SKILL.md (orchestrator)
 - `scripts/generate_voiceover.py` → ElevenLabs API + optional Whisper transcription (Phase 5)
 - `scripts/search_music.py` → Freesound API for CC music (Phase 5)
 
-`templates/` files are copied into generated projects. `patterns/` files are referenced for visual techniques — `metallic-swoosh.md` documents *why* clipPath transitions are banned (black-sliver artifacts).
+`templates/` files are copied into generated projects. `patterns/` files are referenced for visual techniques — `metallic-swoosh.md` documents *why* clipPath transitions are banned (black-sliver artifacts), and `cli-terminal-capture.md` documents the `asciinema` + `agg` workflow for the optional real-terminal-clip path (the dependency-free authored-terminal path uses `templates/scene-terminal.html`; the asciinema clip path uses `templates/scene-terminal-clip.html`).
 
 ## Working with the skill scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,12 @@ These are enforced verbally in the `## DON'Ts` section of `SKILL.md`. If you mod
 - **Change phase logic** → edit the relevant `workflows/phase-N-*.md`; update the prerequisite list in `SKILL.md` if a new required file is introduced.
 - **Adjust prerequisite checks** → the `## Prerequisites` block in `SKILL.md` (runs at skill entry).
 - **Bump skill metadata** → frontmatter at top of `SKILL.md` (especially `allowed-tools` if a new MCP tool is needed).
+- **Bump the GSAP version** → the CDN `<script>` tags carry a Subresource Integrity hash (`integrity="sha384-…" crossorigin="anonymous"`), pinned to `gsap@3.14.2`. Changing the version *requires* recomputing the hash, or the script is blocked and every scene renders without animation (caught by `npx hyperframes validate` in Phase 4/5). Update **all** occurrences together — `templates/scene-*.html`, the skeletons in `workflows/phase-3-design.md` + `workflows/phase-4-production.md`, and every `example/**/*.html`:
+  ```bash
+  V=3.x.y   # new version
+  H="sha384-$(curl -sL https://cdn.jsdelivr.net/npm/gsap@$V/dist/gsap.min.js | openssl dgst -sha384 -binary | base64)"
+  # then replace src=…/gsap@$V/… and integrity="$H" in every file above (keep them in lock-step)
+  ```
 
 ## Installation paths users invoke
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ These are enforced verbally in the `## DON'Ts` section of `SKILL.md`. If you mod
 - **Never animate `display`, `visibility`, or call `.play()` inside a timeline.** Breaks HyperFrames' deterministic seek; use `opacity` + `pointer-events`.
 - **Never animate `<img>` dimensions directly.** Wrap the `<img>` in a non-timed `<div>` and animate the wrapper's `transform`. Direct dimension tweens trigger layout recompute that breaks deterministic seek.
 - **Never use `tl.from()` for opacity tweens.** GSAP records the end-state at registration; if the CSS rest is `opacity:0` the recorded end is `opacity:0` (the tween goes nowhere), and under stagger later instances re-hide elements earlier ones revealed. Always use `tl.fromTo(target, {opacity:0,...}, {opacity:1,...}, pos)`.
+- **Never ship a bare `<video>` in a clip scene.** The runtime only frame-syncs videos carrying `data-start`; with 2+ clip scenes bare videos cross-route (wrong footage / black) while every gate passes green. The explicit contract is `id` + `data-start="0"` + `data-duration` (loader's crossfade-extended window, not the bare clip length) + `data-media-start` (storyboard `Clip in`) + `data-track-index="0"` — see `workflows/phase-3-design.md` § Clip scene.
 
 ## Common edits
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Each phase has a user-approval checkpoint before proceeding to the next.
 | Whisper | Recommended | `pip install openai-whisper` — voiceover timing verification |
 | `espeak-ng` | Optional | `brew install espeak-ng` / `apt install espeak-ng` — only needed for non-English voiceover via `hyperframes tts` fallback |
 | `--experimentalScreencast` (chrome-devtools MCP) | No | Enables `screencast` web-clip capture; without it, web scenes fall back to screenshots. |
-| `asciinema` + `agg` | No | Optional true terminal-clip recording for CLI scenes; without them, CLI scenes use the authored-terminal path. |
+| `asciinema` + `agg` | No | Optional true terminal-clip recording for CLI scenes; without them, CLI scenes use the authored-terminal path. Install: `brew install asciinema agg` (macOS) · `apt install asciinema && cargo install --git https://github.com/asciinema/agg` (Debian/Ubuntu). See [`patterns/cli-terminal-capture.md`](patterns/cli-terminal-capture.md) for the full recording workflow. |
 
 ### Required Skills
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -3,7 +3,7 @@ name: hve-spielberg
 description: >
   End-to-end video production pipeline with design thinking. 6-phase orchestrator:
   Discovery (design thinking + context) → Storytelling (narrative + storyboard) →
-  Capture (Chrome DevTools screenshots) → Design (HyperFrames scene templates) →
+  Capture (Chrome DevTools screenshots + screencast clips, asciinema terminal recording) → Design (HyperFrames scene templates) →
   Production (HyperFrames composition) → Audio &amp; Render (ElevenLabs + Whisper + Freesound music).
   Three content modes: promo (marketing), showcase (portfolio/demo), or tutorial (walkthrough/how-to). Triggers: "create video",
   "promo video", "showcase video", "tutorial video", "walkthrough video", "how-to video", "product video", "demo video", "launch video".

--- a/SKILL.md
+++ b/SKILL.md
@@ -33,7 +33,7 @@ ffmpeg -version       # ✓ for audio/video processing
 echo "ELEVENLABS_API_KEY: $([ -n \"$ELEVENLABS_API_KEY\" ] && echo '✓ set (high-quality TTS)' || echo '○ not set — Phase 5 will fall back to npx hyperframes tts (Kokoro-82M, local, lower quality)')"
 echo "FREESOUND_API_KEY: $([ -n \"$FREESOUND_API_KEY\" ] && echo '✓ set (music search)' || echo '○ not set (music search disabled, user-provided only)')"
 echo "screencast (web clips): optional — needs the chrome-devtools MCP started with --experimentalScreencast=true; falls back to screenshots if unavailable"
-echo "asciinema+agg (CLI clip recording): optional — $(command -v asciinema >/dev/null && command -v agg >/dev/null && echo '✓ available' || echo '○ not installed; CLI scenes use the authored-terminal path')"
+echo "asciinema+agg (CLI clip recording): optional — $(command -v asciinema >/dev/null && command -v agg >/dev/null && echo '✓ available (real terminal-clip path enabled — see patterns/cli-terminal-capture.md)' || echo '○ not installed (CLI scenes use the authored-terminal path; install: brew install asciinema agg  ·  apt install asciinema && cargo install --git https://github.com/asciinema/agg)')"
 ```
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ description: >
   "promo video", "showcase video", "tutorial video", "walkthrough video", "how-to video", "product video", "demo video", "launch video".
 user-invocable: true
 argument-hint: "[project-dir] [--mode new|continue|jump] [--phase 0|1|2|3|4|5]"
-allowed-tools: Bash(npm:*), Bash(npx:*), Bash(ffmpeg:*), Bash(python:*), Bash(python3:*), Bash(pip:*), Bash(whisper:*), Bash(curl:*), Bash(git:*), Bash(asciinema:*), Bash(agg:*), Bash(timeout:*), Bash(ffprobe:*), Read, Write, Edit, Glob, Grep, AskUserQuestion, Skill, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__take_snapshot, mcp__chrome-devtools__click, mcp__chrome-devtools__wait_for, mcp__chrome-devtools__evaluate_script, mcp__chrome-devtools__list_pages, mcp__chrome-devtools__new_page, mcp__chrome-devtools__select_page, mcp__chrome-devtools__screencast_start, mcp__chrome-devtools__screencast_stop, mcp__chrome-devtools__resize_page
+allowed-tools: Bash(npm:*), Bash(npx:*), Bash(ffmpeg:*), Bash(python:*), Bash(python3:*), Bash(pip:*), Bash(whisper:*), Bash(curl:*), Bash(git:*), Bash(asciinema:*), Bash(agg:*), Bash(timeout:*), Bash(ffprobe:*), Bash(script:*), Read, Write, Edit, Glob, Grep, AskUserQuestion, Skill, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__take_snapshot, mcp__chrome-devtools__click, mcp__chrome-devtools__wait_for, mcp__chrome-devtools__evaluate_script, mcp__chrome-devtools__emulate, mcp__chrome-devtools__list_pages, mcp__chrome-devtools__new_page, mcp__chrome-devtools__select_page, mcp__chrome-devtools__screencast_start, mcp__chrome-devtools__screencast_stop, mcp__chrome-devtools__resize_page
 version: "0.0.3"
 updated: "2026-06-08"
 ---
@@ -33,7 +33,7 @@ ffmpeg -version       # ✓ for audio/video processing
 echo "ELEVENLABS_API_KEY: $([ -n \"$ELEVENLABS_API_KEY\" ] && echo '✓ set (high-quality TTS)' || echo '○ not set — Phase 5 will fall back to npx hyperframes tts (Kokoro-82M, local, lower quality)')"
 echo "FREESOUND_API_KEY: $([ -n \"$FREESOUND_API_KEY\" ] && echo '✓ set (music search)' || echo '○ not set (music search disabled, user-provided only)')"
 echo "screencast (web clips): optional — needs the chrome-devtools MCP started with --experimentalScreencast=true; falls back to screenshots if unavailable"
-echo "asciinema+agg (CLI clip recording): optional — $(command -v asciinema >/dev/null && command -v agg >/dev/null && echo '✓ available (real terminal-clip path enabled — see patterns/cli-terminal-capture.md)' || echo '○ not installed (CLI scenes use the authored-terminal path; install: brew install asciinema agg  ·  apt install asciinema && cargo install --git https://github.com/asciinema/agg)')"
+echo "asciinema+agg+timeout (CLI clip recording): optional — $(command -v asciinema >/dev/null && command -v agg >/dev/null && command -v timeout >/dev/null && echo '✓ available (real terminal-clip path enabled — see patterns/cli-terminal-capture.md)' || echo '○ incomplete (CLI scenes use the authored-terminal path; install — see patterns/cli-terminal-capture.md § Install; macOS: brew install asciinema agg coreutils)')"
 ```
 
 ```bash
@@ -165,6 +165,7 @@ See [workflows/phase-5-audio.md](workflows/phase-5-audio.md)
 - **Never animate `display`, `visibility`, or call `.play()` in timelines** — Breaks HyperFrames' deterministic seek; use `opacity` + `pointer-events`
 - **Never animate `<img>` dimensions directly** — Causes layout recompute that confuses deterministic seek. Wrap each `<img>` in a non-timed `<div>` and animate the wrapper's `transform` (`scale`, `translate`) instead
 - **Never use `tl.from()` for opacity tweens with stagger** — GSAP records the END state at registration; if CSS rest is `opacity:0` the recorded end is `opacity:0` and the animation goes nowhere. With stagger, later instances re-hide elements that earlier instances revealed. **Always use `tl.fromTo(target, {opacity:0,...}, {opacity:1,...}, pos)`.** See `patterns/visual-patterns.md` § "tl.from() stagger trap"
+- **Never ship a bare `<video>` in a clip scene** — the runtime only frame-syncs videos carrying `data-start`; bare videos cross-route with 2+ clip scenes (wrong footage / black) while all gates pass green. Every clip `<video>` carries the explicit contract: `id` + `data-start="0"` + `data-duration` (the loader's full crossfade-extended window) + `data-media-start` (storyboard `Clip in`) + `data-track-index="0"`. See `workflows/phase-3-design.md` § Clip scene
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ description: >
   "promo video", "showcase video", "tutorial video", "walkthrough video", "how-to video", "product video", "demo video", "launch video".
 user-invocable: true
 argument-hint: "[project-dir] [--mode new|continue|jump] [--phase 0|1|2|3|4|5]"
-allowed-tools: Bash(npm:*), Bash(npx:*), Bash(ffmpeg:*), Bash(python:*), Bash(python3:*), Bash(pip:*), Bash(whisper:*), Bash(curl:*), Bash(git:*), Read, Write, Edit, Glob, Grep, AskUserQuestion, Skill, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__take_snapshot, mcp__chrome-devtools__click, mcp__chrome-devtools__wait_for, mcp__chrome-devtools__evaluate_script, mcp__chrome-devtools__list_pages, mcp__chrome-devtools__new_page, mcp__chrome-devtools__select_page, mcp__chrome-devtools__screencast_start, mcp__chrome-devtools__screencast_stop, mcp__chrome-devtools__resize_page
+allowed-tools: Bash(npm:*), Bash(npx:*), Bash(ffmpeg:*), Bash(python:*), Bash(python3:*), Bash(pip:*), Bash(whisper:*), Bash(curl:*), Bash(git:*), Bash(asciinema:*), Bash(agg:*), Bash(timeout:*), Bash(ffprobe:*), Read, Write, Edit, Glob, Grep, AskUserQuestion, Skill, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__take_snapshot, mcp__chrome-devtools__click, mcp__chrome-devtools__wait_for, mcp__chrome-devtools__evaluate_script, mcp__chrome-devtools__list_pages, mcp__chrome-devtools__new_page, mcp__chrome-devtools__select_page, mcp__chrome-devtools__screencast_start, mcp__chrome-devtools__screencast_stop, mcp__chrome-devtools__resize_page
 version: "0.0.2"
 updated: "2026-06-04"
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -10,8 +10,8 @@ description: >
 user-invocable: true
 argument-hint: "[project-dir] [--mode new|continue|jump] [--phase 0|1|2|3|4|5]"
 allowed-tools: Bash(npm:*), Bash(npx:*), Bash(ffmpeg:*), Bash(python:*), Bash(python3:*), Bash(pip:*), Bash(whisper:*), Bash(curl:*), Bash(git:*), Bash(asciinema:*), Bash(agg:*), Bash(timeout:*), Bash(ffprobe:*), Read, Write, Edit, Glob, Grep, AskUserQuestion, Skill, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__take_screenshot, mcp__chrome-devtools__take_snapshot, mcp__chrome-devtools__click, mcp__chrome-devtools__wait_for, mcp__chrome-devtools__evaluate_script, mcp__chrome-devtools__list_pages, mcp__chrome-devtools__new_page, mcp__chrome-devtools__select_page, mcp__chrome-devtools__screencast_start, mcp__chrome-devtools__screencast_stop, mcp__chrome-devtools__resize_page
-version: "0.0.2"
-updated: "2026-06-04"
+version: "0.0.3"
+updated: "2026-06-08"
 ---
 
 # hve-spielberg — AI Video Production Pipeline

--- a/example/index.html
+++ b/example/index.html
@@ -70,7 +70,7 @@
          style="opacity:0"></div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
   <script>
     window.__timelines = window.__timelines || {};
     const tl = gsap.timeline({ paused: true });

--- a/example/scenes/00-hero.html
+++ b/example/scenes/00-hero.html
@@ -65,7 +65,7 @@
       }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/example/scenes/01-how.html
+++ b/example/scenes/01-how.html
@@ -124,7 +124,7 @@
       }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/example/scenes/02-pipeline.html
+++ b/example/scenes/02-pipeline.html
@@ -104,7 +104,7 @@
       }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/example/scenes/03-features.html
+++ b/example/scenes/03-features.html
@@ -76,7 +76,7 @@
       }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/example/scenes/04-cta.html
+++ b/example/scenes/04-cta.html
@@ -68,7 +68,7 @@
       }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/patterns/INDEX.md
+++ b/patterns/INDEX.md
@@ -11,6 +11,7 @@ Quick map: *"I need to do X"* → *"read this file."* hve-spielberg leans on the
 | `marker-highlight.md` | 5 word-emphasis patterns: highlight, circle, burst, scribble, sketchout — for kicker lines, stat reveals, before/after |
 | `transition-catalog.md` | One-page map of every CSS transition family + catalog blocks, mapped to product-video moments |
 | `anti-slop.md` | Cardinal sins, soft tells, polish tells — distinguishes "shipped by a marketer" from "AI default output". Includes **§ AI Tool Promo Specifics** (dogfooding loop, show-don't-tell, 1-based phase numbering) and **§ CTA discipline** (full URL on screen, match canonical command). |
+| `cli-terminal-capture.md` | Professional CLI scene recording via `asciinema` + `agg`: install, shell pre-flight (prompt, secrets, size), recording flags, cast editing, theme→palette pairing, MP4 render, quality gate, troubleshooting. Read when the storyboard calls for a real terminal clip; for the no-dep fallback see `templates/scene-terminal.html`. |
 
 ## HyperFrames skill references (in `~/.claude/skills/hyperframes/`)
 

--- a/patterns/cli-terminal-capture.md
+++ b/patterns/cli-terminal-capture.md
@@ -100,7 +100,9 @@ The single autonomous sequence (also reproduced in
 # Terminal size is set via COLUMNS/LINES (portable across asciinema 2.x Python and
 # 3.x Rust; `rec --cols/--rows` exist only on 3.x and error out on 2.x). COLUMNS=175
 # keeps wide output (kubectl get, docker ps) from wrapping — size it to the scene.
-timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash TERM=xterm-256color \
+# RECORD_TIMEOUT = storyboard `Record timeout` (default scene_duration + 2s).
+RECORD_TIMEOUT="${RECORD_TIMEOUT:-60}"
+timeout "${RECORD_TIMEOUT}s" env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash TERM=xterm-256color \
   LANG="${LANG:-C.UTF-8}" COLUMNS=175 LINES=32 PS1='$ ' \
   asciinema rec --idle-time-limit 1.5 \
     --command "<cmd-from-storyboard>" \

--- a/patterns/cli-terminal-capture.md
+++ b/patterns/cli-terminal-capture.md
@@ -1,0 +1,234 @@
+# CLI / Terminal Capture — asciinema + agg
+
+How to produce a **professional terminal clip** for a hve-spielberg CLI scene
+when the storyboard calls for *real* command output (a deploy log, a build
+spinner, an interactive prompt). For the dependency-free fallback, see the
+"authored terminal" path documented inline in
+`workflows/phase-2-capture.md` (the `templates/scene-terminal.html` archetype).
+
+The chrome-devtools MCP cannot screencast a terminal — there is no DOM page.
+For real terminal motion we record with [asciinema](https://github.com/asciinema/asciinema),
+post-process the cast, then render it to MP4 with
+[agg](https://github.com/asciinema/agg). The clip is then composed via the
+Layer-A `templates/scene-terminal-clip.html` archetype, which wraps the video
+in a macOS-style window for brand parity with screenshot mockups.
+
+## When to use this path
+
+Pick the **asciinema path** when:
+
+- The motion is the point (a streaming build log, a progress bar, animated
+  spinners, a TUI like `htop`/`lazygit`, a real `npm install` cascade).
+- The duration is short (≤ 8s of meaningful action) and you want the *real*
+  cadence, not a synthetic one.
+- You're recording your own machine and can scrub secrets cleanly.
+
+Pick the **authored-terminal path** (`templates/scene-terminal.html`) when:
+
+- Output is short (≤ 5 lines) and a deterministic typewriter reveal reads
+  cleaner than real-time scroll.
+- The command takes long enough to be boring without heavy editing.
+- You don't have `asciinema` + `agg` installed and don't want a new dep.
+- The environment is sensitive (production hosts, real credentials in PATH).
+
+## Feature detection (already wired)
+
+`SKILL.md` Prerequisites and `workflows/phase-2-capture.md` Capture-source
+detection both probe `command -v asciinema` and `command -v agg`. If either
+is missing the workflow degrades to the authored-terminal path and tells the
+user. Do not hard-fail.
+
+## Install
+
+```bash
+# macOS
+brew install asciinema agg
+
+# Debian / Ubuntu
+sudo apt install asciinema
+cargo install --git https://github.com/asciinema/agg   # agg has no apt package
+
+# Arch
+sudo pacman -S asciinema
+yay -S agg-bin
+
+# Any OS (pip fallback for asciinema)
+pipx install asciinema
+```
+
+Verify:
+
+```bash
+asciinema --version    # 2.x+
+agg --version          # 1.4+
+```
+
+## Recording (pre-flight)
+
+The cast is **as professional as the shell you record in.** Spend 60 seconds
+preparing the environment — it's the difference between a polished clip and a
+debug log.
+
+1. **Clean shell, no secrets.** Open a fresh terminal in a throwaway dir.
+   - `unset HISTFILE` to avoid leaking shell history into TUI prompts.
+   - `env | grep -iE 'token|key|secret|password'` should be empty in the
+     window. Use a sub-shell with `env -i HOME=$HOME PATH=$PATH SHELL=$SHELL bash`
+     if you need a hard reset.
+   - Hide personal data: real names, customer hostnames, internal URLs.
+2. **Brand-aligned prompt.** Set a minimal prompt that matches the video's
+   visual identity. A noisy oh-my-zsh prompt reads as amateur.
+   ```bash
+   export PS1='$ '                              # bash
+   PROMPT='%F{green}$%f '                       # zsh
+   set fish_greeting "" ; function fish_prompt; printf '$ '; end   # fish
+   ```
+3. **Sized window, fixed font.** The render width must equal the agg output
+   width (default `144 cols × 32 rows`). Resize the terminal before
+   recording — agg captures cols/rows from the cast header, so a resize
+   mid-record produces a jagged frame.
+   ```bash
+   printf '\e[8;32;144t'   # request 32 rows × 144 cols (most modern terms)
+   ```
+4. **Theme.** Dark background reads best in video and matches the
+   `scene-terminal-clip.html` chrome. Disable transparency.
+5. **Pacing.** Type at a deliberate pace — real keystrokes look more
+   authentic than pasted commands. asciinema preserves your timing.
+
+## Recording
+
+Two modes — both produce a `.cast` JSON file you can edit before rendering.
+
+### A. Drive a single command
+
+```bash
+asciinema rec --cols 144 --rows 32 \
+  --idle-time-limit 1.5 \
+  --command "npm run deploy" \
+  cast.cast
+```
+
+- `--idle-time-limit 1.5` collapses any pause longer than 1.5s to 1.5s.
+  This is the single most important post-production lever — without it, a
+  `npm install` clip is 90% empty waiting frames.
+- `--command` exits when the command exits, giving a clean tail.
+
+### B. Drive a shell interactively (for multi-step demos)
+
+```bash
+asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 cast.cast
+# ... type commands ...
+exit                                              # ends the recording
+```
+
+## Editing the cast (optional, recommended)
+
+The `.cast` file is newline-delimited JSON: the first line is the header,
+each subsequent line is `[time_seconds, "o", "text"]`. You can hand-edit it.
+
+Common edits:
+
+- **Trim a slow tail.** Open in your editor, delete trailing lines whose
+  `time` exceeds the desired duration. Update no other field.
+- **Speed up a section.** Multiply the `time` field of a contiguous block by
+  `0.5` (2× faster). Keep monotonic ordering — don't let times go backwards.
+- **Redact a string.** Find-replace the literal token in the `text` field.
+  Quote handling: the value is a JSON string, so backslash-escape `"` and
+  control bytes (asciinema already does this on capture).
+
+Re-validate by playing it back: `asciinema play cast.cast`.
+
+## Render to MP4
+
+`agg` renders a `.cast` to GIF by default; for hve-spielberg we want MP4.
+Two routes — pick the one that lands on PATH.
+
+### Route 1 — agg → MP4 directly (agg ≥ 1.5)
+
+```bash
+agg \
+  --cols 144 --rows 32 \
+  --font-size 28 \
+  --theme monokai \
+  --speed 1.0 \
+  --fps-cap 30 \
+  cast.cast public/clips/scene-{NN}-{slug}.mp4
+```
+
+### Route 2 — agg → GIF → MP4 via ffmpeg (older agg)
+
+```bash
+agg --cols 144 --rows 32 --font-size 28 --theme monokai \
+    cast.cast cast.gif
+
+ffmpeg -y -i cast.gif \
+  -movflags +faststart \
+  -pix_fmt yuv420p \
+  -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
+  public/clips/scene-{NN}-{slug}.mp4
+```
+
+The `scale=trunc(iw/2)*2:trunc(ih/2)*2` filter forces even dimensions —
+H.264 requires it and a raw agg GIF will sometimes be odd-width.
+
+### Theme palette → brand parity
+
+| `--theme` | Vibe | Pairs with palette |
+|---|---|---|
+| `monokai` | Warm dev-default | `bold-energetic`, `warm-editorial` |
+| `solarized-dark` | Calm corporate | `clean-corporate`, `dark-premium` |
+| `dracula` | High-contrast purple | `neon-electric`, `jewel-rich` |
+| `nord` | Cool Nordic | `clean-corporate`, `nature-earth` |
+| `gruvbox-dark` | Retro warm | `warm-editorial` |
+| `github-dark` | Neutral grey | Most palettes |
+
+For a custom theme pass `--theme bg,fg,palette` with explicit hex
+(e.g. `--theme 0a0a0a,eaeaea,...`). Match the scene's `background` so the
+clip blends seamlessly with the wrapper.
+
+## Quality gate (in addition to the Phase 2 footage gate)
+
+Before accepting a terminal clip:
+
+- **Font size ≥ 24px effective** in the rendered frame. Agg's default is
+  small; bump `--font-size` to 28–32 for 1920×1080 compositions.
+- **No prompt cruft.** No `(env)` markers, no git branch names from
+  oh-my-zsh, no virtualenv indicators (unless they're the story).
+- **No long idle gaps.** If the clip has > 1s of motionless frames,
+  re-render with a lower `--idle-time-limit`.
+- **Aspect.** Agg renders 144×32 → roughly 16:5. The clip wrapper
+  (`scene-terminal-clip.html`) crops/letterboxes inside its window chrome,
+  but if your composition is 9:16 prefer 80×40 cols and a larger font.
+- **Audio.** Cast files have no audio. The clip is muted by design — the
+  voiceover narrates over it.
+
+## Wiring into a scene
+
+After the MP4 is at `public/clips/scene-{NN}-{slug}.mp4`:
+
+1. Author the scene from `templates/scene-terminal-clip.html` into
+   `scenes/{NN}-terminal-clip.html`. Replace `NN` and `slug` and adjust the
+   window title (`zsh`, `npm`, `deploy`) to match the command.
+2. The wrapper's `data-composition-id`, animation, and clip-frame chrome are
+   pre-wired — never animate the `<video>` itself, animate the `.term-frame`
+   wrapper per the *no img-dimension tween* DON'T.
+3. Phase 4 root composition picks the clip up automatically (HyperFrames
+   auto-syncs `<video>` `currentTime` to the scene window).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Cast plays at wrong size | `--cols`/`--rows` flags missing on `rec` | Re-record; cast header is authoritative |
+| MP4 is letterboxed weirdly | agg cols/rows ≠ rec cols/rows | Pass the same `--cols`/`--rows` to `agg` |
+| Render fails: "height not divisible by 2" | agg GIF odd-width | Use the ffmpeg `scale=trunc(...)*2` filter |
+| Spinner shows blank chars | Terminal font missing glyphs | `agg --font-family "JetBrains Mono"` (or the font installed on the render host) |
+| Output trails off mid-line | `asciinema rec --command` killed by SIGINT | Re-run; let the command exit naturally, or use interactive mode + `exit` |
+| Text reads too small in render | Default `--font-size 14` | Use `--font-size 28` or larger for 1080p |
+
+## See also
+
+- `templates/scene-terminal-clip.html` — the clip-wrapper scene archetype
+- `templates/scene-terminal.html` — the authored (no-dep) fallback
+- `workflows/phase-2-capture.md` § "Recording a CLI scene (terminal)"
+- asciinema docs: <https://docs.asciinema.org/>
+- agg repo: <https://github.com/asciinema/agg>

--- a/patterns/cli-terminal-capture.md
+++ b/patterns/cli-terminal-capture.md
@@ -65,7 +65,8 @@ pipx install asciinema
 Verify:
 
 ```bash
-asciinema --version    # 2.x+
+asciinema --version    # 2.x (Python) or 3.x (Rust) — both fine; size is set via
+                       # COLUMNS/LINES below, not `rec --cols/--rows` (3.x-only, errors on 2.x)
 agg --version          # 1.4+
 ```
 
@@ -92,19 +93,33 @@ The single autonomous sequence (also reproduced in
 
 ```bash
 # Record — non-interactive, PTY-isolated, timeout-bounded.
-timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash PS1='$ ' \
-  asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 \
+# Terminal size is set via COLUMNS/LINES (portable across asciinema 2.x Python and
+# 3.x Rust; `rec --cols/--rows` exist only on 3.x and error out on 2.x). COLUMNS=175
+# keeps wide output (kubectl get, docker ps) from wrapping — size it to the scene.
+timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash TERM=xterm-256color \
+  COLUMNS=175 LINES=32 PS1='$ ' \
+  asciinema rec --idle-time-limit 1.5 \
     --command "<cmd-from-storyboard>" \
     public/clips/scene-{NN}-{slug}.cast \
   || true
 
-# Render — also autonomous.
+# Render — agg emits a GIF (it ignores the output extension), so render to .gif…
 agg --cols 144 --rows 32 --font-size 28 --theme monokai --fps-cap 30 \
   public/clips/scene-{NN}-{slug}.cast \
+  public/clips/scene-{NN}-{slug}.gif
+
+# …then normalize to constant-fps H.264. REQUIRED, not optional: agg emits
+# change-only frames (a 2-line deploy can be 2–4 frames total) that break
+# seek-driven <video> sync. `fps=30` rebuilds a constant timeline; the
+# scale=trunc(...)*2 keeps dimensions even for H.264.
+ffmpeg -y -i public/clips/scene-{NN}-{slug}.gif \
+  -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
+  -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
   public/clips/scene-{NN}-{slug}.mp4
 
-# Verify.
-ffprobe -v error -show_entries format=duration -of csv=p=0 \
+# Verify — expect ~30 × duration frames at a constant rate (not 2–4 sparse frames).
+ffprobe -v error -count_frames -select_streams v:0 \
+  -show_entries stream=nb_read_frames,avg_frame_rate -of default=noprint_wrappers=1 \
   public/clips/scene-{NN}-{slug}.mp4
 ```
 
@@ -159,7 +174,7 @@ For multi-step demos where you *want* a human typing for cadence and
 authenticity, the same tools work as a hand-recorded session:
 
 ```bash
-asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 cast.cast
+COLUMNS=175 LINES=32 asciinema rec --idle-time-limit 1.5 cast.cast
 # ... type commands ...
 exit
 ```
@@ -190,36 +205,46 @@ Re-validate by playing it back: `asciinema play cast.cast`.
 
 ## Render to MP4
 
-`agg` renders a `.cast` to GIF by default; for hve-spielberg we want MP4.
-Two routes — pick the one that lands on PATH.
-
-### Route 1 — agg → MP4 directly (agg ≥ 1.5)
-
-```bash
-agg \
-  --cols 144 --rows 32 \
-  --font-size 28 \
-  --theme monokai \
-  --speed 1.0 \
-  --fps-cap 30 \
-  cast.cast public/clips/scene-{NN}-{slug}.mp4
-```
-
-### Route 2 — agg → GIF → MP4 via ffmpeg (older agg)
+`agg` is a **GIF generator** — it writes a GIF regardless of the output filename,
+so naming the output `.mp4` just produces a GIF inside an `.mp4` name (wrong
+container; seek-driven players and `<video>` sync choke on it). There is **one**
+reliable path: render to `.gif`, then normalize to constant-fps H.264 with ffmpeg.
 
 ```bash
-agg --cols 144 --rows 32 --font-size 28 --theme monokai \
-    cast.cast cast.gif
+# 1. Render the cast to a GIF.
+agg --cols 144 --rows 32 --font-size 28 --theme monokai --speed 1.0 --fps-cap 30 \
+    cast.cast public/clips/scene-{NN}-{slug}.gif
 
-ffmpeg -y -i cast.gif \
-  -movflags +faststart \
-  -pix_fmt yuv420p \
+# 2. Normalize to constant-fps MP4 — REQUIRED, not just for odd widths.
+ffmpeg -y -i public/clips/scene-{NN}-{slug}.gif \
   -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
+  -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
   public/clips/scene-{NN}-{slug}.mp4
 ```
 
-The `scale=trunc(iw/2)*2:trunc(ih/2)*2` filter forces even dimensions —
-H.264 requires it and a raw agg GIF will sometimes be odd-width.
+Why step 2 is mandatory: `agg` emits **change-only frames**, so a short clip
+(a 2-line deploy) can be 2–4 frames total at a variable sub-1fps rate, and a GIF
+decodes to `yuv444p`. Constant-fps players and HyperFrames' seek-driven `<video>`
+sync mishandle such sparse VFR, and `yuv444p` isn't broadly supported. `fps=30`
+rebuilds a constant 30fps timeline (a ~5s clip → ~150 frames), `pix_fmt yuv420p`
+fixes the colorspace, and `scale=trunc(...)*2` forces even dimensions for H.264.
+`agg --fps-cap` is a *cap*, not a floor, so it does not produce constant fps.
+
+### Fill a longer scene window (freeze-extend)
+
+A terminal reveal often finishes in ~4s while the narration over it runs ~20s.
+Clone the last frame to fill the slot instead of looping or freezing a dead
+`<video>` — swap the step-2 filter for `tpad`:
+
+```bash
+ffmpeg -y -i public/clips/scene-{NN}-{slug}.gif \
+  -vf "tpad=stop_mode=clone:stop_duration=N,fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
+  -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
+  public/clips/scene-{NN}-{slug}.mp4
+```
+
+`N = scene_duration − clip_duration` (e.g. a 5s clip + `stop_duration=8` → 13s,
+constant 30fps).
 
 ### Theme palette → brand parity
 
@@ -262,16 +287,20 @@ After the MP4 is at `public/clips/scene-{NN}-{slug}.mp4`:
 2. The wrapper's `data-composition-id`, animation, and clip-frame chrome are
    pre-wired — never animate the `<video>` itself, animate the `.term-frame`
    wrapper per the *no img-dimension tween* DON'T.
-3. Phase 4 root composition picks the clip up automatically (HyperFrames
-   auto-syncs `<video>` `currentTime` to the scene window).
+3. Give the scene's `<video>` its explicit clip contract — `id` + `data-start="0"`
+   + `data-duration` (= clip seconds) + `data-track-index="0"` (pre-wired in the
+   template). HyperFrames frame-syncs `currentTime` to the scene window from those
+   attributes; a bare `<video>` is not time-synced and, with 2+ clip scenes,
+   cross-routes (wrong footage / black).
 
 ## Troubleshooting
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Cast plays at wrong size | `--cols`/`--rows` flags missing on `rec` | Re-record; cast header is authoritative |
-| MP4 is letterboxed weirdly | agg cols/rows ≠ rec cols/rows | Pass the same `--cols`/`--rows` to `agg` |
-| Render fails: "height not divisible by 2" | agg GIF odd-width | Use the ffmpeg `scale=trunc(...)*2` filter |
+| Cast recorded at wrong size / wide output wraps | terminal size not set (or `rec --cols/--rows` used — 3.x-only, errors on 2.x) | Set `COLUMNS=175 LINES=32` in the `rec` env; the cast header records that size |
+| MP4 won't open / stutters in player or scene | agg emits change-only frames (2–4 total); an agg `.mp4` is really a GIF | Run the mandatory `fps=30` ffmpeg normalize (step 2 above) |
+| MP4 is letterboxed weirdly | agg `--cols`/`--rows` ≠ the recorded `COLUMNS`/`LINES` | Match `agg --cols/--rows` to the cast header size |
+| Render fails: "height not divisible by 2" | agg GIF odd-width | Use the ffmpeg `scale=trunc(...)*2` filter (in the normalize) |
 | Spinner shows blank chars | Terminal font missing glyphs | `agg --font-family "JetBrains Mono"` (or the font installed on the render host) |
 | Output trails off mid-line | `asciinema rec --command` killed by SIGINT | Re-run; let the command exit naturally, or use interactive mode + `exit` |
 | Text reads too small in render | Default `--font-size 14` | Use `--font-size 28` or larger for 1080p |

--- a/patterns/cli-terminal-capture.md
+++ b/patterns/cli-terminal-capture.md
@@ -15,13 +15,17 @@ in a macOS-style window for brand parity with screenshot mockups.
 
 ## When to use this path
 
-Pick the **asciinema path** when:
+Pick the **asciinema path** (skill-driven; see "Recording mode — autonomous"
+below) when:
 
 - The motion is the point (a streaming build log, a progress bar, animated
   spinners, a TUI like `htop`/`lazygit`, a real `npm install` cascade).
 - The duration is short (≤ 8s of meaningful action) and you want the *real*
   cadence, not a synthetic one.
-- You're recording your own machine and can scrub secrets cleanly.
+- The command is **non-interactive** — it runs to completion (or to a
+  timeout) without needing keyboard input. asciinema's `--command` mode
+  lets the skill execute it autonomously via its Bash tool; the user
+  never touches the keyboard.
 
 Pick the **authored-terminal path** (`templates/scene-terminal.html`) when:
 
@@ -29,7 +33,9 @@ Pick the **authored-terminal path** (`templates/scene-terminal.html`) when:
   cleaner than real-time scroll.
 - The command takes long enough to be boring without heavy editing.
 - You don't have `asciinema` + `agg` installed and don't want a new dep.
-- The environment is sensitive (production hosts, real credentials in PATH).
+- The command genuinely needs a human at the keyboard (interactive prompts,
+  mouse-driven TUIs).
+- The environment is sensitive in ways `env -i` can't fully sanitize.
 
 ## Feature detection (already wired)
 
@@ -63,62 +69,107 @@ asciinema --version    # 2.x+
 agg --version          # 1.4+
 ```
 
-## Recording (pre-flight)
+## Recording mode — **autonomous (skill-driven)**
 
-The cast is **as professional as the shell you record in.** Spend 60 seconds
-preparing the environment — it's the difference between a polished clip and a
-debug log.
+The skill executes `asciinema` itself via its Bash tool. **The user does
+not open a terminal or run anything by hand.** This works because
+`asciinema rec --command "<cmd>"` is non-interactive: asciinema allocates
+its own PTY, runs the command headless, captures stdout/stderr with
+timing, and exits when the command exits.
 
-1. **Clean shell, no secrets.** Open a fresh terminal in a throwaway dir.
-   - `unset HISTFILE` to avoid leaking shell history into TUI prompts.
-   - `env | grep -iE 'token|key|secret|password'` should be empty in the
-     window. Use a sub-shell with `env -i HOME=$HOME PATH=$PATH SHELL=$SHELL bash`
-     if you need a hard reset.
-   - Hide personal data: real names, customer hostnames, internal URLs.
-2. **Brand-aligned prompt.** Set a minimal prompt that matches the video's
-   visual identity. A noisy oh-my-zsh prompt reads as amateur.
-   ```bash
-   export PS1='$ '                              # bash
-   PROMPT='%F{green}$%f '                       # zsh
-   set fish_greeting "" ; function fish_prompt; printf '$ '; end   # fish
-   ```
-3. **Sized window, fixed font.** The render width must equal the agg output
-   width (default `144 cols × 32 rows`). Resize the terminal before
-   recording — agg captures cols/rows from the cast header, so a resize
-   mid-record produces a jagged frame.
-   ```bash
-   printf '\e[8;32;144t'   # request 32 rows × 144 cols (most modern terms)
-   ```
-4. **Theme.** Dark background reads best in video and matches the
-   `scene-terminal-clip.html` chrome. Disable transparency.
-5. **Pacing.** Type at a deliberate pace — real keystrokes look more
-   authentic than pasted commands. asciinema preserves your timing.
+Three things make autonomous recording reliable:
 
-## Recording
+- **`--command`** — non-interactive single-shot mode. No stdin needed.
+- **`timeout Ns`** — bounds runaway / non-terminating commands (`htop`,
+  dev servers). Exit code 124 is non-fatal; the partial cast up to the
+  timeout is still valid and renderable.
+- **`env -i …`** — scrubs the parent environment so stray tokens, custom
+  `PS1`, oh-my-zsh git status, virtualenv markers, etc. don't leak into
+  the recording's PTY.
 
-Two modes — both produce a `.cast` JSON file you can edit before rendering.
-
-### A. Drive a single command
+The single autonomous sequence (also reproduced in
+`workflows/phase-2-capture.md`):
 
 ```bash
-asciinema rec --cols 144 --rows 32 \
-  --idle-time-limit 1.5 \
-  --command "npm run deploy" \
-  cast.cast
+# Record — non-interactive, PTY-isolated, timeout-bounded.
+timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash PS1='$ ' \
+  asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 \
+    --command "<cmd-from-storyboard>" \
+    public/clips/scene-{NN}-{slug}.cast \
+  || true
+
+# Render — also autonomous.
+agg --cols 144 --rows 32 --font-size 28 --theme monokai --fps-cap 30 \
+  public/clips/scene-{NN}-{slug}.cast \
+  public/clips/scene-{NN}-{slug}.mp4
+
+# Verify.
+ffprobe -v error -show_entries format=duration -of csv=p=0 \
+  public/clips/scene-{NN}-{slug}.mp4
 ```
 
-- `--idle-time-limit 1.5` collapses any pause longer than 1.5s to 1.5s.
-  This is the single most important post-production lever — without it, a
-  `npm install` clip is 90% empty waiting frames.
-- `--command` exits when the command exits, giving a clean tail.
+The storyboard carries the inputs the skill needs:
 
-### B. Drive a shell interactively (for multi-step demos)
+```
+Capture: terminal-clip
+Command: shipfast deploy --env staging
+Record timeout: 8s          # scene duration + ~2s
+```
+
+Why `--idle-time-limit 1.5` matters: an unmodified `npm install` cast is
+~90% motionless waiting frames. With `--idle-time-limit` set, every pause
+longer than 1.5s collapses to 1.5s, giving a clip that *feels* real-time
+without dragging.
+
+### Edge cases the autonomous path handles
+
+- **Long-running / non-terminating commands.** `timeout` bounds them. Set
+  the storyboard's `Record timeout` to `scene_duration + ~2s` so the
+  recorded footage matches the slot.
+- **Commands needing piped input.** Wrap in `bash -c`:
+  ```bash
+  --command "bash -c 'printf \"y\\n\" | npm uninstall foo'"
+  ```
+- **Commands needing secrets** (e.g. an API key). Inject *only* the needed
+  variable into the scrubbed env:
+  ```bash
+  env -i HOME=$HOME PATH=$PATH SHELL=/bin/bash PS1='$ ' \
+      DEPLOY_TOKEN="$DEPLOY_TOKEN" \
+    asciinema rec ...
+  ```
+  The token is in the PTY's process env but **never echoed to the
+  recording** — asciinema captures stdout, not env dumps.
+- **TTY allocation failure** (rare; some sandboxes). If `asciinema rec`
+  errors with *"could not allocate pty"*, fall back to GNU `script`:
+  ```bash
+  script -qc "<cmd>" /dev/null      # produces a typescript file
+  ```
+  Convert by prepending an asciinema v2 header line
+  `{"version":2,"width":144,"height":32}` and timing-stamping each line;
+  if that's too brittle for the scene, fall back to the authored-terminal
+  path.
+- **Commands genuinely needing a human** (interactive prompts, mouse-driven
+  TUIs). Out of scope for autonomous mode — switch the storyboard's
+  `Capture:` to `terminal` (authored-typewriter path) or `supplied`
+  (user provides their own MP4).
+
+## Recording mode — interactive (sub-case)
+
+For multi-step demos where you *want* a human typing for cadence and
+authenticity, the same tools work as a hand-recorded session:
 
 ```bash
 asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 cast.cast
 # ... type commands ...
-exit                                              # ends the recording
+exit
 ```
+
+The pre-flight checklist (clean shell, brand prompt, sized window, dark
+theme, deliberate pacing) applies. The skill does not drive this mode —
+it's a user-side path for scenes where deterministic `--command` mode
+won't capture the intent. Drop the resulting cast into the storyboard's
+expected location (`public/clips/scene-{NN}-{slug}.cast`) and the skill
+will pick up from the render step.
 
 ## Editing the cast (optional, recommended)
 

--- a/patterns/cli-terminal-capture.md
+++ b/patterns/cli-terminal-capture.md
@@ -40,15 +40,17 @@ Pick the **authored-terminal path** (`templates/scene-terminal.html`) when:
 ## Feature detection (already wired)
 
 `SKILL.md` Prerequisites and `workflows/phase-2-capture.md` Capture-source
-detection both probe `command -v asciinema` and `command -v agg`. If either
-is missing the workflow degrades to the authored-terminal path and tells the
+detection both probe `command -v asciinema`, `command -v agg`, and
+`command -v timeout` (GNU coreutils — absent on stock macOS). If any is
+missing the workflow degrades to the authored-terminal path and tells the
 user. Do not hard-fail.
 
 ## Install
 
 ```bash
-# macOS
-brew install asciinema agg
+# macOS — coreutils provides GNU `timeout` (stock macOS has none; verified:
+# brew's coreutils installs it unprefixed)
+brew install asciinema agg coreutils
 
 # Debian / Ubuntu
 sudo apt install asciinema
@@ -89,37 +91,46 @@ Three things make autonomous recording reliable:
   the recording's PTY.
 
 The single autonomous sequence (also reproduced in
-`workflows/phase-2-capture.md`):
+`workflows/phase-2-capture.md` — edit BOTH together):
 
 ```bash
 # Record — non-interactive, PTY-isolated, timeout-bounded.
+# LANG must survive the env scrub — asciinema 2.x (Python) aborts without a
+# UTF-8 locale ("asciinema needs a UTF-8 native locale to run").
 # Terminal size is set via COLUMNS/LINES (portable across asciinema 2.x Python and
 # 3.x Rust; `rec --cols/--rows` exist only on 3.x and error out on 2.x). COLUMNS=175
 # keeps wide output (kubectl get, docker ps) from wrapping — size it to the scene.
 timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash TERM=xterm-256color \
-  COLUMNS=175 LINES=32 PS1='$ ' \
+  LANG="${LANG:-C.UTF-8}" COLUMNS=175 LINES=32 PS1='$ ' \
   asciinema rec --idle-time-limit 1.5 \
     --command "<cmd-from-storyboard>" \
     public/clips/scene-{NN}-{slug}.cast \
-  || true
+  || true   # exit 124 (timeout) is non-fatal; check the .cast exists before
+            # rendering — || true also masks real failures (missing binary, locale)
+[ -s public/clips/scene-{NN}-{slug}.cast ] || { echo "no cast recorded — falling back to authored-terminal"; }
 
-# Render — agg emits a GIF (it ignores the output extension), so render to .gif…
-agg --cols 144 --rows 32 --font-size 28 --theme monokai --fps-cap 30 \
+# Render — agg emits a GIF (it ignores the output extension), so render to a TEMP
+# .gif (multi-MB intermediate — keep it out of public/clips/). Never pass
+# --cols/--rows: agg reads the size from the cast header (the COLUMNS/LINES
+# recorded above); a mismatch wraps/letterboxes the output.
+agg --font-size 28 --theme monokai --fps-cap 30 \
   public/clips/scene-{NN}-{slug}.cast \
-  public/clips/scene-{NN}-{slug}.gif
+  "${TMPDIR:-/tmp}/scene-{NN}-{slug}.gif"
 
 # …then normalize to constant-fps H.264. REQUIRED, not optional: agg emits
 # change-only frames (a 2-line deploy can be 2–4 frames total) that break
 # seek-driven <video> sync. `fps=30` rebuilds a constant timeline; the
 # scale=trunc(...)*2 keeps dimensions even for H.264.
-ffmpeg -y -i public/clips/scene-{NN}-{slug}.gif \
+ffmpeg -y -i "${TMPDIR:-/tmp}/scene-{NN}-{slug}.gif" \
   -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
   -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
   public/clips/scene-{NN}-{slug}.mp4
 
 # Verify — expect ~30 × duration frames at a constant rate (not 2–4 sparse frames).
-ffprobe -v error -count_frames -select_streams v:0 \
-  -show_entries stream=nb_read_frames,avg_frame_rate -of default=noprint_wrappers=1 \
+# nb_frames is read from the container header ffmpeg just wrote — no -count_frames
+# full decode needed.
+ffprobe -v error -select_streams v:0 \
+  -show_entries stream=nb_frames,avg_frame_rate -of default=noprint_wrappers=1 \
   public/clips/scene-{NN}-{slug}.mp4
 ```
 
@@ -148,19 +159,21 @@ without dragging.
 - **Commands needing secrets** (e.g. an API key). Inject *only* the needed
   variable into the scrubbed env:
   ```bash
-  env -i HOME=$HOME PATH=$PATH SHELL=/bin/bash PS1='$ ' \
+  env -i HOME=$HOME PATH=$PATH SHELL=/bin/bash LANG="${LANG:-C.UTF-8}" PS1='$ ' \
       DEPLOY_TOKEN="$DEPLOY_TOKEN" \
     asciinema rec ...
   ```
   The token is in the PTY's process env but **never echoed to the
   recording** — asciinema captures stdout, not env dumps.
 - **TTY allocation failure** (rare; some sandboxes). If `asciinema rec`
-  errors with *"could not allocate pty"*, fall back to GNU `script`:
+  errors with *"could not allocate pty"*, fall back to `script` — note the
+  two incompatible syntaxes:
   ```bash
-  script -qc "<cmd>" /dev/null      # produces a typescript file
+  script -qc "<cmd>" /dev/null      # GNU/Linux (util-linux)
+  script -q /dev/null <cmd>         # BSD/macOS — has no -c flag
   ```
   Convert by prepending an asciinema v2 header line
-  `{"version":2,"width":144,"height":32}` and timing-stamping each line;
+  `{"version":2,"width":175,"height":32}` and timing-stamping each line;
   if that's too brittle for the scene, fall back to the authored-terminal
   path.
 - **Commands genuinely needing a human** (interactive prompts, mouse-driven
@@ -210,13 +223,17 @@ so naming the output `.mp4` just produces a GIF inside an `.mp4` name (wrong
 container; seek-driven players and `<video>` sync choke on it). There is **one**
 reliable path: render to `.gif`, then normalize to constant-fps H.264 with ffmpeg.
 
+Same render + normalize steps as the autonomous sequence above (keep the two
+in sync — the flags must not drift):
+
 ```bash
-# 1. Render the cast to a GIF.
-agg --cols 144 --rows 32 --font-size 28 --theme monokai --speed 1.0 --fps-cap 30 \
-    cast.cast public/clips/scene-{NN}-{slug}.gif
+# 1. Render the cast to a TEMP GIF. No --cols/--rows — agg reads the size from
+#    the cast header; a mismatch wraps/letterboxes.
+agg --font-size 28 --theme monokai --fps-cap 30 \
+    cast.cast "${TMPDIR:-/tmp}/scene-{NN}-{slug}.gif"
 
 # 2. Normalize to constant-fps MP4 — REQUIRED, not just for odd widths.
-ffmpeg -y -i public/clips/scene-{NN}-{slug}.gif \
+ffmpeg -y -i "${TMPDIR:-/tmp}/scene-{NN}-{slug}.gif" \
   -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
   -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
   public/clips/scene-{NN}-{slug}.mp4
@@ -288,10 +305,13 @@ After the MP4 is at `public/clips/scene-{NN}-{slug}.mp4`:
    pre-wired — never animate the `<video>` itself, animate the `.term-frame`
    wrapper per the *no img-dimension tween* DON'T.
 3. Give the scene's `<video>` its explicit clip contract — `id` + `data-start="0"`
-   + `data-duration` (= clip seconds) + `data-track-index="0"` (pre-wired in the
-   template). HyperFrames frame-syncs `currentTime` to the scene window from those
+   + `data-duration` (= the loader's full crossfade-extended window) +
+   `data-media-start` (= storyboard `Clip in`, `0` if whole) + `data-track-index="0"`
+   (pre-wired in the template; substitute the `DUR`/`MSTART` placeholders).
+   HyperFrames frame-syncs `currentTime` to the scene window from those
    attributes; a bare `<video>` is not time-synced and, with 2+ clip scenes,
-   cross-routes (wrong footage / black).
+   cross-routes (wrong footage / black). Full contract: `workflows/phase-3-design.md`
+   § Clip scene.
 
 ## Troubleshooting
 
@@ -299,7 +319,7 @@ After the MP4 is at `public/clips/scene-{NN}-{slug}.mp4`:
 |---|---|---|
 | Cast recorded at wrong size / wide output wraps | terminal size not set (or `rec --cols/--rows` used — 3.x-only, errors on 2.x) | Set `COLUMNS=175 LINES=32` in the `rec` env; the cast header records that size |
 | MP4 won't open / stutters in player or scene | agg emits change-only frames (2–4 total); an agg `.mp4` is really a GIF | Run the mandatory `fps=30` ffmpeg normalize (step 2 above) |
-| MP4 is letterboxed weirdly | agg `--cols`/`--rows` ≠ the recorded `COLUMNS`/`LINES` | Match `agg --cols/--rows` to the cast header size |
+| MP4 is letterboxed weirdly | agg `--cols`/`--rows` passed and ≠ the recorded `COLUMNS`/`LINES` | Drop `--cols/--rows` entirely — agg reads the size from the cast header |
 | Render fails: "height not divisible by 2" | agg GIF odd-width | Use the ffmpeg `scale=trunc(...)*2` filter (in the normalize) |
 | Spinner shows blank chars | Terminal font missing glyphs | `agg --font-family "JetBrains Mono"` (or the font installed on the render host) |
 | Output trails off mid-line | `asciinema rec --command` killed by SIGINT | Re-run; let the command exit naturally, or use interactive mode + `exit` |

--- a/patterns/transition-catalog.md
+++ b/patterns/transition-catalog.md
@@ -60,7 +60,7 @@ These come from `references/transitions/catalog.md` and bite if violated:
 - **Only fade the INCOMING scene's opacity 0→1.** Don't simultaneously fade the outgoing scene 1→0 — that lets the body color contribute to the composite during the crossfade (visible as darkening). The outgoing scene stays at opacity 1 below and is occluded naturally as the incoming one covers it.
 - **Body background should be white** (or whatever neutral matches your scene backgrounds). If anything ever exposes the body — a single-frame timing gap, a clipping artifact — white reads as intentional pacing. Black reads as a render bug.
 - **Scene 1 visible by default** — no `opacity: 0`. Scenes 2+ start at `opacity: 0` on the *container*; GSAP reveals them.
-- **No `class="clip"` on standalone scene divs.** Only the root composition gets `data-composition-id`/`data-start`/`data-duration`.
+- **No `class="clip"` on standalone scene divs.** Only the root composition gets `data-composition-id`/`data-start`/`data-duration` — with one exception: the `<video>` inside a clip scene carries its own `data-start`/`data-duration`/`data-media-start`/`data-track-index` per the explicit clip contract (`workflows/phase-3-design.md` § Clip scene). Never strip those.
 - **Z-index on exit-revealing transitions** (gravity drop, zoom out, diagonal split): outgoing scene goes ON TOP (`z-index: 10`) so it exits while revealing the new scene behind (`z-index: 1`).
 - **Light-leak overlays must be larger than the frame (2400px+)** so the edge never crosses the canvas during sweep. A visible-shape leak looks fake.
 - **Glitch RGB overlays at 35% opacity with NORMAL blend mode** — `mix-blend-mode: multiply` is invisible on dark backgrounds, which is exactly when you'd reach for glitch.

--- a/templates/scene-clip.html
+++ b/templates/scene-clip.html
@@ -34,7 +34,7 @@
       [data-composition-id="scene-NN-clip"] .clip-vid{display:block;width:100%;height:auto}
       /* device-frame chrome, brand color-grade, vignette, restyled cursor go here */
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/templates/scene-clip.html
+++ b/templates/scene-clip.html
@@ -1,11 +1,19 @@
-<!-- Clip scene archetype (HyperFrames sub-composition). Wiring S: a plain
-     <video> is auto-discovered and currentTime-synced to this scene's window
-     (set by the root loader's data-start/data-duration). Animate the wrapper,
-     NEVER the <video> dimensions. Clip-own audio is OFF in v1 (muted). -->
+<!-- Clip scene archetype (HyperFrames sub-composition). Wiring S: give the
+     <video> the explicit clip contract — id + data-start="0" +
+     data-duration="<clip seconds>" + data-track-index="0" — so the runtime
+     frame-syncs its currentTime to this scene's window. data-start is relative
+     to THIS scene; data-duration = (out-in)/speed. The runtime only seeks
+     videos that carry data-start: a bare <video> is auto-discovered for display
+     but never time-synced, so it's safe ONLY as the single clip in a
+     composition (and even then it never advances past frame 0). With 2+ clip
+     scenes, bare videos cross-route — one scene plays another's footage,
+     another plays black. Animate the wrapper, NEVER the <video> dimensions.
+     Clip-own audio is OFF in v1 (muted). -->
 <template id="scene-NN-clip-template">
   <div data-composition-id="scene-NN-clip" data-width="1920" data-height="1080">
     <div class="clip-frame">
-      <video class="clip-vid" src="public/clips/scene-NN-slug.mp4" muted playsinline></video>
+      <video id="vid-NN" class="clip-vid" src="public/clips/scene-NN-slug.mp4"
+             data-start="0" data-duration="DUR" data-track-index="0" muted playsinline></video>
     </div>
     <style>
       [data-composition-id="scene-NN-clip"]{position:absolute;inset:0;display:flex;

--- a/templates/scene-clip.html
+++ b/templates/scene-clip.html
@@ -1,19 +1,29 @@
 <!-- Clip scene archetype (HyperFrames sub-composition). Wiring S: give the
-     <video> the explicit clip contract — id + data-start="0" +
-     data-duration="<clip seconds>" + data-track-index="0" — so the runtime
-     frame-syncs its currentTime to this scene's window. data-start is relative
-     to THIS scene; data-duration = (out-in)/speed. The runtime only seeks
-     videos that carry data-start: a bare <video> is auto-discovered for display
-     but never time-synced, so it's safe ONLY as the single clip in a
-     composition (and even then it never advances past frame 0). With 2+ clip
-     scenes, bare videos cross-route — one scene plays another's footage,
-     another plays black. Animate the wrapper, NEVER the <video> dimensions.
-     Clip-own audio is OFF in v1 (muted). -->
+     <video> the explicit clip contract — id + data-start="0" + data-duration +
+     data-media-start + data-track-index="0" — so the runtime frame-syncs its
+     currentTime to this scene's window. data-start is relative to THIS scene.
+     Placeholders to substitute when authoring:
+       DUR    = this scene loader's FULL data-duration from index.html, i.e.
+                (out-in)/speed PLUS the 0.4s crossfade extension (see
+                patterns/transition-catalog.md). If the video's track ends at
+                the nominal clip length, the runtime hides it
+                (visibility:hidden) during the crossfade and the frame blanks.
+       MSTART = the storyboard's `Clip in` (trim offset into the source file,
+                seconds; 0 if untrimmed). Without data-media-start the runtime
+                plays from source t=0 and ignores the trim — and desyncs from
+                Phase 5's clip-audio extraction (CIN).
+     The runtime only seeks videos that carry data-start: a bare <video> is
+     auto-discovered for display but never time-synced, so it's safe ONLY as
+     the single clip in a composition (and even then it never advances past
+     frame 0). With 2+ clip scenes, bare videos cross-route — one scene plays
+     another's footage, another plays black. Animate the wrapper, NEVER the
+     <video> dimensions. Clip-own audio is OFF in v1 (muted). -->
 <template id="scene-NN-clip-template">
   <div data-composition-id="scene-NN-clip" data-width="1920" data-height="1080">
     <div class="clip-frame">
       <video id="vid-NN" class="clip-vid" src="public/clips/scene-NN-slug.mp4"
-             data-start="0" data-duration="DUR" data-track-index="0" muted playsinline></video>
+             data-start="0" data-duration="DUR" data-media-start="MSTART"
+             data-track-index="0" muted playsinline></video>
     </div>
     <style>
       [data-composition-id="scene-NN-clip"]{position:absolute;inset:0;display:flex;

--- a/templates/scene-recap.html
+++ b/templates/scene-recap.html
@@ -29,7 +29,7 @@
         display:flex;align-items:center;justify-content:center;background:#0a72ef;color:#fff;
         font-size:28px;font-weight:600;font-family:"Geist Mono","JetBrains Mono",monospace}
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/templates/scene-terminal-clip.html
+++ b/templates/scene-terminal-clip.html
@@ -1,0 +1,53 @@
+<!-- Terminal clip scene archetype (asciinema + agg path). Wraps a pre-rendered
+     MP4 (public/clips/scene-NN-slug.mp4 from `agg`) in a macOS-style window
+     so it composes alongside browser-mockup scenes with brand parity.
+     Wiring: a plain <video> is auto-discovered by HyperFrames and
+     currentTime-synced to this scene's window (set by the root loader's
+     data-start/data-duration). Animate the WRAPPER (.term-frame) only —
+     never the <video> dimensions (see DON'T: img/video dimension tweens).
+     Authored by Phase 2 after asciinema → agg has produced the MP4.
+     See patterns/cli-terminal-capture.md for the recording workflow. -->
+<template id="scene-NN-terminal-clip-template">
+  <div data-composition-id="scene-NN-terminal-clip" data-width="1920" data-height="1080">
+    <div class="term-frame">
+      <div class="term-bar">
+        <span class="dot dr"></span><span class="dot dy"></span><span class="dot dg"></span>
+        <span class="term-title">zsh</span>                <!-- REPLACE: command/shell label -->
+      </div>
+      <video class="term-vid" src="public/clips/scene-NN-slug.mp4" muted playsinline></video>
+    </div>
+    <style>
+      [data-composition-id="scene-NN-terminal-clip"]{position:absolute;inset:0;display:flex;
+        align-items:center;justify-content:center;background:#0a0a0a /* brand canvas */}
+      [data-composition-id="scene-NN-terminal-clip"] .term-frame{position:relative;width:80%;
+        border-radius:12px;overflow:hidden;background:#161616;
+        box-shadow:0 40px 120px rgba(0,0,0,.5);
+        outline:1px solid rgba(255,255,255,.06);
+        visibility:hidden;opacity:0}
+      [data-composition-id="scene-NN-terminal-clip"] .term-bar{display:flex;align-items:center;
+        gap:8px;padding:12px 16px;background:#222}
+      [data-composition-id="scene-NN-terminal-clip"] .dot{width:12px;height:12px;border-radius:50%}
+      [data-composition-id="scene-NN-terminal-clip"] .dr{background:#ff5f56}
+      [data-composition-id="scene-NN-terminal-clip"] .dy{background:#ffbd2e}
+      [data-composition-id="scene-NN-terminal-clip"] .dg{background:#27c93f}
+      [data-composition-id="scene-NN-terminal-clip"] .term-title{margin-left:8px;color:#888;
+        font-size:20px;font-family:"Geist Mono","JetBrains Mono",monospace}
+      [data-composition-id="scene-NN-terminal-clip"] .term-vid{display:block;width:100%;height:auto}
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      // Entrance: animate the WRAPPER only (autoAlpha + fromTo per the stagger-trap rule).
+      tl.fromTo('[data-composition-id="scene-NN-terminal-clip"] .term-frame',
+        { y: 40, autoAlpha: 0 }, { y: 0, autoAlpha: 1, duration: 0.6, ease: "power3.out" }, 0.1);
+      // Optional legibility punch-in (spec §7.2a): scale the .term-frame wrapper toward a
+      // text region when output text renders <24px effective. Never scale the <video>.
+      // tl.to('[data-composition-id="scene-NN-terminal-clip"] .term-frame',
+      //   { scale: 1.8, transformOrigin: "12% 50%", duration: 0.6, ease: "power2.inOut" }, 3.0);
+      // tl.to('[data-composition-id="scene-NN-terminal-clip"] .term-frame',
+      //   { scale: 1.0, transformOrigin: "12% 50%", duration: 0.6, ease: "power2.inOut" }, 6.0);
+      window.__timelines["scene-NN-terminal-clip"] = tl;
+    </script>
+  </div>
+</template>

--- a/templates/scene-terminal-clip.html
+++ b/templates/scene-terminal-clip.html
@@ -46,7 +46,7 @@
         font-size:20px;font-family:"Geist Mono","JetBrains Mono",monospace}
       [data-composition-id="scene-NN-terminal-clip"] .term-vid{display:block;width:100%;height:auto}
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/templates/scene-terminal-clip.html
+++ b/templates/scene-terminal-clip.html
@@ -2,13 +2,19 @@
      MP4 (public/clips/scene-NN-slug.mp4 from `agg` → `ffmpeg`) in a macOS-style
      window so it composes alongside browser-mockup scenes with brand parity.
      Wiring: give the <video> the explicit clip contract — id + data-start="0" +
-     data-duration="<clip seconds>" + data-track-index="0" — so HyperFrames
-     frame-syncs its currentTime to this scene's window. A bare <video> is
-     auto-discovered for display but never time-synced, so it's safe ONLY as the
-     single clip in a composition; with 2+ clip scenes, bare videos cross-route
-     (one scene plays another's footage, another plays black). Animate the
-     WRAPPER (.term-frame) only — never the <video> dimensions (see DON'T:
-     img/video dimension tweens).
+     data-duration + data-media-start + data-track-index="0" — so HyperFrames
+     frame-syncs its currentTime to this scene's window. Substitute:
+       DUR    = the scene loader's FULL data-duration from index.html, i.e.
+                (out-in)/speed PLUS the 0.4s crossfade extension — a track that
+                ends at the nominal clip length goes visibility:hidden during
+                the crossfade and the frame blanks.
+       MSTART = the storyboard's `Clip in` (trim offset, seconds; 0 if whole).
+     A bare <video> (no data-start) is auto-discovered for display but never
+     time-synced, so it's safe ONLY as the single clip in a composition (and
+     even then it never advances past frame 0); with 2+ clip scenes, bare
+     videos cross-route (one scene plays another's footage, another plays
+     black). Animate the WRAPPER (.term-frame) only — never the <video>
+     dimensions (see DON'T: img/video dimension tweens).
      Authored by Phase 2 after asciinema → agg has produced the MP4.
      See patterns/cli-terminal-capture.md for the recording workflow. -->
 <template id="scene-NN-terminal-clip-template">
@@ -19,7 +25,8 @@
         <span class="term-title">zsh</span>                <!-- REPLACE: command/shell label -->
       </div>
       <video id="vid-NN" class="term-vid" src="public/clips/scene-NN-slug.mp4"
-             data-start="0" data-duration="DUR" data-track-index="0" muted playsinline></video>
+             data-start="0" data-duration="DUR" data-media-start="MSTART"
+             data-track-index="0" muted playsinline></video>
     </div>
     <style>
       [data-composition-id="scene-NN-terminal-clip"]{position:absolute;inset:0;display:flex;

--- a/templates/scene-terminal-clip.html
+++ b/templates/scene-terminal-clip.html
@@ -1,10 +1,14 @@
 <!-- Terminal clip scene archetype (asciinema + agg path). Wraps a pre-rendered
-     MP4 (public/clips/scene-NN-slug.mp4 from `agg`) in a macOS-style window
-     so it composes alongside browser-mockup scenes with brand parity.
-     Wiring: a plain <video> is auto-discovered by HyperFrames and
-     currentTime-synced to this scene's window (set by the root loader's
-     data-start/data-duration). Animate the WRAPPER (.term-frame) only —
-     never the <video> dimensions (see DON'T: img/video dimension tweens).
+     MP4 (public/clips/scene-NN-slug.mp4 from `agg` → `ffmpeg`) in a macOS-style
+     window so it composes alongside browser-mockup scenes with brand parity.
+     Wiring: give the <video> the explicit clip contract — id + data-start="0" +
+     data-duration="<clip seconds>" + data-track-index="0" — so HyperFrames
+     frame-syncs its currentTime to this scene's window. A bare <video> is
+     auto-discovered for display but never time-synced, so it's safe ONLY as the
+     single clip in a composition; with 2+ clip scenes, bare videos cross-route
+     (one scene plays another's footage, another plays black). Animate the
+     WRAPPER (.term-frame) only — never the <video> dimensions (see DON'T:
+     img/video dimension tweens).
      Authored by Phase 2 after asciinema → agg has produced the MP4.
      See patterns/cli-terminal-capture.md for the recording workflow. -->
 <template id="scene-NN-terminal-clip-template">
@@ -14,7 +18,8 @@
         <span class="dot dr"></span><span class="dot dy"></span><span class="dot dg"></span>
         <span class="term-title">zsh</span>                <!-- REPLACE: command/shell label -->
       </div>
-      <video class="term-vid" src="public/clips/scene-NN-slug.mp4" muted playsinline></video>
+      <video id="vid-NN" class="term-vid" src="public/clips/scene-NN-slug.mp4"
+             data-start="0" data-duration="DUR" data-track-index="0" muted playsinline></video>
     </div>
     <style>
       [data-composition-id="scene-NN-terminal-clip"]{position:absolute;inset:0;display:flex;

--- a/templates/scene-terminal.html
+++ b/templates/scene-terminal.html
@@ -30,7 +30,7 @@
       [data-composition-id="scene-NN-terminal"] .caret{color:#eaeaea}
       [data-composition-id="scene-NN-terminal"] .oline{visibility:hidden;opacity:0;color:#b9f}
     </style>
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/templates/storyboard.md
+++ b/templates/storyboard.md
@@ -25,7 +25,7 @@ All times are in **seconds**. Each scene below maps 1:1 to a HyperFrames sub-com
 **Clip in/out:** {in}s–{out}s                                *(trim into the source; default: whole clip)*
 **Speed:** 1.0                                               *(defaultPlaybackRate; >1 only over dead air)*
 **Clip audio:** none                                         *(default; set to a volume 0.0–1.0 to play the clip's own sound and duck the VO under it — Phase 5 Step 5.3a, spec §5.1/§14)*
-**Captions:** auto                                           *(auto = Whisper on the VO)*
+**Captions:** auto                                           *(auto = Whisper on the VO; `carried` = on-screen copy already shows the spoken line, tutorial-only)*
 **Chapter:** {title}                                         *(tutorial mode only — chapter/section name)*
 **Step label:** Step {n} of {M}                              *(tutorial mode only — on-screen step pill)*
 

--- a/templates/storyboard.md
+++ b/templates/storyboard.md
@@ -18,7 +18,9 @@ All times are in **seconds**. Each scene below maps 1:1 to a HyperFrames sub-com
 **Window:** {start}s → {end}s ({duration}s)
 **Scene file:** `scenes/{NN}-{slug}.html`
 **Screenshot:** `public/screenshots/scene-{NN}-{desc}.png` *(omit if pure design scene)*
-**Capture:** screenshot | screencast | terminal | supplied   *(default: screenshot)*
+**Capture:** screenshot | screencast | terminal | terminal-clip | supplied   *(default: screenshot)*
+**Command:** `<exact shell command>`                          *(REQUIRED when Capture: terminal-clip — the skill executes this autonomously via `asciinema rec --command`. Use `bash -c '…'` for multi-step pipelines. Omit for Capture: terminal, which uses authored output.)*
+**Record timeout:** {seconds}                                *(terminal-clip only; default: scene duration + 2s — bounds non-terminating commands like dev servers / TUIs)*
 **Clip:** `public/clips/scene-{NN}-{slug}.mp4`                *(present when Capture yields a clip)*
 **Clip in/out:** {in}s–{out}s                                *(trim into the source; default: whole clip)*
 **Speed:** 1.0                                               *(defaultPlaybackRate; >1 only over dead air)*

--- a/workflows/phase-1-storytelling.md
+++ b/workflows/phase-1-storytelling.md
@@ -227,11 +227,17 @@ Generate `storyboard.md` from `templates/storyboard.md`.
 Each scene defaults to a still **screenshot**. A scene may instead be a **clip**
 (real motion footage) by setting `Capture:` to `screencast` (web app, Phase 2),
 `terminal` (CLI tool — an authored animated terminal from real command output),
-or `supplied` (you provide the file). Clip scenes use the clip fields in the
-storyboard template (`Clip`, `Clip in/out`, `Speed`, `Captions`). A clip scene's
-on-screen duration is the footage length (see Phase 4), so plan the scene's slot
-around the real clip length. Clips are available in **all** content modes; in
-`promo` they must be device-framed accents (Phase 4).
+`terminal-clip` (CLI tool — a **real** recording: Phase 2 runs the command
+autonomously via asciinema + agg; requires a `Command:` field with the exact
+shell command and honors `Record timeout:`, default scene duration + 2s — see
+`patterns/cli-terminal-capture.md`), or `supplied` (you provide the file).
+Prefer `terminal-clip` over `terminal` when the command's real output matters
+(deploys, test runs, scaffolding) — it degrades to the authored-terminal path
+automatically if asciinema/agg aren't installed. Clip scenes use the clip
+fields in the storyboard template (`Clip`, `Clip in/out`, `Speed`, `Captions`).
+A clip scene's on-screen duration is the footage length (see Phase 4), so plan
+the scene's slot around the real clip length. Clips are available in **all**
+content modes; in `promo` they must be device-framed accents (Phase 4).
 
 ## Step 1.7: Which App Views to Capture
 

--- a/workflows/phase-2-capture.md
+++ b/workflows/phase-2-capture.md
@@ -104,7 +104,10 @@ Autonomous sequence the skill executes (no user input between steps):
 #    COLUMNS/LINES set the terminal size — portable across asciinema 2.x (Python)
 #    and 3.x (Rust); `rec --cols/--rows` exist only on 3.x and error out on 2.x.
 #    COLUMNS=175 keeps wide output (kubectl get, docker ps) from wrapping.
-timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash TERM=xterm-256color \
+#    RECORD_TIMEOUT comes from the storyboard's `Record timeout` field (default
+#    scene_duration + 2s) — bounds non-terminating commands to the scene's slot.
+RECORD_TIMEOUT="${RECORD_TIMEOUT:-60}"   # seconds, from storyboard `Record timeout`
+timeout "${RECORD_TIMEOUT}s" env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash TERM=xterm-256color \
   LANG="${LANG:-C.UTF-8}" COLUMNS=175 LINES=32 PS1='$ ' \
   asciinema rec --idle-time-limit 1.5 \
     --command "<cmd-from-storyboard>" \
@@ -146,9 +149,10 @@ window for brand parity with browser-mockup scenes. Animate the
 
 **Edge cases the autonomous path handles:**
 
-- *Long-running / non-terminating commands.* `timeout 60s` bounds them; the
-  partial cast is still valid. Adjust the timeout per scene duration (a
-  6s scene shouldn't record 60s of footage — pick `timeout = scene_duration + 2s`).
+- *Long-running / non-terminating commands.* `timeout` bounds them; the
+  partial cast is still valid. Set `RECORD_TIMEOUT` from the storyboard's
+  `Record timeout` (a 6s scene shouldn't record 60s of footage — default is
+  `scene_duration + 2s`).
 - *Commands needing piped input.* Use `--command "bash -c '...'"` with a
   here-doc or `printf ... | <cmd>` inside. asciinema records the resulting PTY.
 - *Commands needing secrets.* Inject only the needed variable into the

--- a/workflows/phase-2-capture.md
+++ b/workflows/phase-2-capture.md
@@ -47,6 +47,15 @@ When `Capture: screencast` and screencast is available (see detection above):
 The recorded `public/clips/scene-{NN}-{slug}.mp4` is consumed by the Layer-A clip-scene
 archetype (`templates/scene-clip.html`) in Phase 3 — no extra wiring here.
 
+> **Screencast frames are change-driven.** CDP emits a frame only when something on the
+> page visually changes — a static view (or a take that opens before any motion) yields a
+> 0-byte / near-empty clip with sparse, irregular PTS. Two fixes: **lead every take with
+> motion** (start `screencast_start` *before* the scripted action, or nudge a scroll/cursor
+> first) so the opening frame is captured, and after `screencast_stop` **normalize the PTS**
+> with `ffmpeg -i in.mp4 -r 30 -pix_fmt yuv420p out.mp4` so the change-driven timing becomes a
+> constant 30fps the renderer can footage-lock. If the clip is still empty, fall back to
+> `take_screenshot` (step 6).
+
 ### Recording a CLI scene (terminal)
 
 CLI tools cannot be screencast (no DOM page). Two paths — pick by the
@@ -84,20 +93,34 @@ Autonomous sequence the skill executes (no user input between steps):
 # 1. Record — non-interactive, PTY-isolated, timeout-bounded.
 #    --idle-time-limit collapses dead air (npm install would be 90% waiting otherwise).
 #    PS1='$ ' is exported into the child PTY so the prompt is brand-clean.
-#    HISTFILE unset and a sub-env keeps stray secrets out of the recording.
-timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash PS1='$ ' \
-  asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 \
+#    COLUMNS/LINES set the terminal size — portable across asciinema 2.x (Python)
+#    and 3.x (Rust); `rec --cols/--rows` exist only on 3.x and error out on 2.x.
+#    COLUMNS=175 keeps wide output (kubectl get, docker ps) from wrapping.
+timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash TERM=xterm-256color \
+  COLUMNS=175 LINES=32 PS1='$ ' \
+  asciinema rec --idle-time-limit 1.5 \
     --command "<cmd-from-storyboard>" \
     public/clips/scene-{NN}-{slug}.cast \
   || true   # exit 124 (timeout) is non-fatal — the cast up to that point is valid
 
-# 2. Render the cast to MP4 — also autonomous; no user input.
+# 2. Render — agg emits a GIF (it ignores the output extension), so render to .gif…
 agg --cols 144 --rows 32 --font-size 28 --theme monokai --fps-cap 30 \
   public/clips/scene-{NN}-{slug}.cast \
+  public/clips/scene-{NN}-{slug}.gif
+
+# 3. Normalize to constant-fps MP4 — REQUIRED: agg emits change-only frames (a
+#    short clip may be 2–4 frames) that break seek-driven <video> sync. If the
+#    narration outlasts the clip, swap the filter for
+#    tpad=stop_mode=clone:stop_duration=N,fps=30 (N = scene − clip; see the pattern doc).
+ffmpeg -y -i public/clips/scene-{NN}-{slug}.gif \
+  -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
+  -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
   public/clips/scene-{NN}-{slug}.mp4
 
-# 3. Verify — fail closed (fall back to authored-terminal) if the MP4 is bad.
-ffprobe -v error -show_entries format=duration -of csv=p=0 \
+# 4. Verify — fail closed (fall back to authored-terminal) if the MP4 is bad.
+#    Expect ~30 × duration frames, not 2–4 sparse ones.
+ffprobe -v error -count_frames -select_streams v:0 \
+  -show_entries stream=nb_read_frames,avg_frame_rate -of default=noprint_wrappers=1 \
   public/clips/scene-{NN}-{slug}.mp4
 ```
 
@@ -117,9 +140,10 @@ window for brand parity with browser-mockup scenes. Animate the
   *"could not allocate pty"*, the skill falls back to `script -qc "<cmd>" /dev/null`
   and converts the typescript via a stub cast header — documented in the
   pattern doc. If that also fails, fall back to the authored-terminal path.
-- *agg only outputs GIF on this host (older versions).* Pipe through ffmpeg
-  with `-vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" -pix_fmt yuv420p` to
-  land on an even-dimension H.264 MP4.
+- *agg always emits a GIF (it ignores the output extension) with change-only
+  frames.* That's why step 3's ffmpeg normalize is mandatory — not an older-agg
+  special case: it rebuilds a constant 30fps timeline so seek-driven `<video>`
+  sync and ordinary players can open the clip.
 
 The Footage-quality gate (below) still applies — bonus terminal-clip checks:
 font ≥ 24px effective, no prompt cruft, no idle gaps > 1s, theme contrast
@@ -228,7 +252,16 @@ A rejected clip falls back to a screenshot or a re-record.
       .forEach(el => el.style.display = 'none');
   }
   ```
-- **Dark mode** — If storyboard specifies dark theme, use `mcp__chrome-devtools__emulate` with `colorScheme: "dark"`
+- **Dark mode (media-query apps)** — If the app reads `prefers-color-scheme`, use `mcp__chrome-devtools__emulate` with `colorScheme: "dark"`
+- **Dark mode (class-based / Tailwind `.dark`)** — `colorScheme` does nothing for apps that toggle a `.dark` class (most Next.js / shadcn). A one-shot injected class is **clobbered by SPA hydration** (React re-renders the root and overwrites it); an init-script loses the same race. Inject a `MutationObserver` via `evaluate_script` *before* navigating, so the class is re-added every time hydration strips it:
+  ```javascript
+  () => {
+    const html = document.documentElement;
+    const set = () => html.classList.add('dark');   // or your app's theme class
+    set();
+    new MutationObserver(set).observe(html, { attributes: true, attributeFilter: ['class'] });
+  }
+  ```
 - **Retina quality** — Always use devicePixelRatio 2+ for crisp screenshots in video
 
 ## Output

--- a/workflows/phase-2-capture.md
+++ b/workflows/phase-2-capture.md
@@ -49,7 +49,8 @@ archetype (`templates/scene-clip.html`) in Phase 3 — no extra wiring here.
 
 ### Recording a CLI scene (terminal)
 
-CLI tools cannot be screencast (no DOM page). Two paths:
+CLI tools cannot be screencast (no DOM page). Two paths — pick by the
+storyboard's intent and what's installed.
 
 **Default — authored terminal scene (deterministic, no dependency):**
 1. Run the real command and capture its stdout (a Bash run, trimmed to the salient lines).
@@ -58,11 +59,53 @@ CLI tools cannot be screencast (no DOM page). Two paths:
 3. This is an authored **scene** (not a clip) — it composes like any Phase-3 scene; no
    `public/clips/` file is produced. It is deterministic and on-brand.
 
-**Optional — true real-time terminal recording (`asciinema` + `agg`, feature-detected):**
-1. Only if both are on PATH (see detection): `asciinema rec --command "<cmd>" cast.cast`.
-2. `agg cast.cast public/clips/scene-{NN}-{slug}.mp4` (render the cast to video).
-3. Compose as a clip via the Layer-A `templates/scene-clip.html` archetype.
-If either tool is missing, use the default authored-terminal path instead.
+**Recommended for motion-heavy CLI — true real-time recording with `asciinema` + `agg`:**
+
+Use this when the *motion is the point* (streaming build logs, spinners,
+TUIs like `lazygit`/`htop`, an interactive prompt). For full guidance —
+pre-flight, cast editing, theme/font choices, troubleshooting — see
+[`patterns/cli-terminal-capture.md`](../patterns/cli-terminal-capture.md).
+
+Quick path (only when both `asciinema` and `agg` are on PATH; otherwise fall
+back to the authored-terminal path):
+
+1. **Prep the shell.** Open a clean terminal, set a minimal prompt, scrub
+   secrets from the environment, resize to 144×32:
+   ```bash
+   unset HISTFILE
+   export PS1='$ '
+   printf '\e[8;32;144t'
+   ```
+2. **Record.** `--idle-time-limit` collapses dead air — without it most
+   `npm install` clips are 90% waiting frames:
+   ```bash
+   asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 \
+     --command "<cmd>" cast.cast
+   ```
+3. **(Optional) Edit the cast.** The `.cast` is line-delimited JSON
+   (`[time, "o", "text"]`). Trim the tail, redact strings, or speed up
+   sections by halving `time` values. See the pattern doc.
+4. **Render to MP4.**
+   ```bash
+   agg --cols 144 --rows 32 --font-size 28 --theme monokai --fps-cap 30 \
+     cast.cast public/clips/scene-{NN}-{slug}.mp4
+   ```
+   If `agg` outputs only GIF on this host (older versions), pipe through
+   ffmpeg with `-vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" -pix_fmt yuv420p`
+   to land on an even-dimension H.264 MP4.
+5. **Compose** the scene from `templates/scene-terminal-clip.html` into
+   `scenes/{NN}-terminal-clip.html` — it wraps the MP4 in a macOS-style
+   window for brand parity with browser-mockup scenes. Animate the
+   `.term-frame` wrapper, never the `<video>` itself.
+6. **Verify** the file exists, is non-empty, and `ffprobe` reports a sane
+   duration. The Footage-quality gate (below) applies — bonus checks:
+   font ≥ 24px effective, no prompt cruft (`(venv)`, oh-my-zsh git status),
+   no idle gaps > 1s, theme contrast matches the scene background.
+
+If either tool is missing, do **not** prompt the user to install — fall back
+to the authored-terminal path and tell them once: *"asciinema/agg not
+detected — using the authored terminal scene. Install with `brew install
+asciinema agg` to record real terminal motion."*
 
 ## Step 2.1: Get App URL
 

--- a/workflows/phase-2-capture.md
+++ b/workflows/phase-2-capture.md
@@ -82,45 +82,60 @@ its own PTY, runs the command headless, captures stdout/stderr/timing,
 and exits when the command exits. Wrap in `timeout` so a runaway or
 non-terminating command (`htop`, dev server) can't stall the phase.
 
-Preconditions (silently fall back to the authored-terminal path if any fail):
+Preconditions (silently fall back to the authored-terminal path if any fail —
+and when falling back, rewrite the scene's storyboard `Capture:` to `terminal`
+so downstream phases don't expect a clip that was never recorded):
 - `command -v asciinema && command -v agg` both succeed
+- `command -v timeout` succeeds (GNU coreutils — absent on stock macOS;
+  `brew install coreutils` provides it)
 - The scene's storyboard entry has `Capture: terminal-clip` AND a `Command:` field
   with the exact shell command to record
 
 Autonomous sequence the skill executes (no user input between steps):
 
 ```bash
+# (Canonical copy: patterns/cli-terminal-capture.md § Recording mode — autonomous.
+#  Edit BOTH together.)
 # 1. Record — non-interactive, PTY-isolated, timeout-bounded.
 #    --idle-time-limit collapses dead air (npm install would be 90% waiting otherwise).
 #    PS1='$ ' is exported into the child PTY so the prompt is brand-clean.
+#    LANG must survive the env scrub — asciinema 2.x (Python) aborts without a
+#    UTF-8 locale ("asciinema needs a UTF-8 native locale to run").
 #    COLUMNS/LINES set the terminal size — portable across asciinema 2.x (Python)
 #    and 3.x (Rust); `rec --cols/--rows` exist only on 3.x and error out on 2.x.
 #    COLUMNS=175 keeps wide output (kubectl get, docker ps) from wrapping.
 timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash TERM=xterm-256color \
-  COLUMNS=175 LINES=32 PS1='$ ' \
+  LANG="${LANG:-C.UTF-8}" COLUMNS=175 LINES=32 PS1='$ ' \
   asciinema rec --idle-time-limit 1.5 \
     --command "<cmd-from-storyboard>" \
     public/clips/scene-{NN}-{slug}.cast \
-  || true   # exit 124 (timeout) is non-fatal — the cast up to that point is valid
+  || true   # exit 124 (timeout) is non-fatal — the cast up to that point is valid.
+            # Verify the .cast exists before step 2: || true also masks a real
+            # failure (missing binary, locale error), and step 2 needs the file.
+[ -s public/clips/scene-{NN}-{slug}.cast ] || { echo "no cast recorded — falling back to authored-terminal"; }
 
-# 2. Render — agg emits a GIF (it ignores the output extension), so render to .gif…
-agg --cols 144 --rows 32 --font-size 28 --theme monokai --fps-cap 30 \
+# 2. Render — agg emits a GIF (it ignores the output extension), so render to a
+#    TEMP .gif (it's a multi-MB intermediate; don't park it in public/clips/).
+#    Never pass --cols/--rows: agg reads the size from the cast header, which
+#    already records the COLUMNS/LINES set above — a mismatch wraps/letterboxes.
+agg --font-size 28 --theme monokai --fps-cap 30 \
   public/clips/scene-{NN}-{slug}.cast \
-  public/clips/scene-{NN}-{slug}.gif
+  "${TMPDIR:-/tmp}/scene-{NN}-{slug}.gif"
 
 # 3. Normalize to constant-fps MP4 — REQUIRED: agg emits change-only frames (a
 #    short clip may be 2–4 frames) that break seek-driven <video> sync. If the
 #    narration outlasts the clip, swap the filter for
 #    tpad=stop_mode=clone:stop_duration=N,fps=30 (N = scene − clip; see the pattern doc).
-ffmpeg -y -i public/clips/scene-{NN}-{slug}.gif \
+ffmpeg -y -i "${TMPDIR:-/tmp}/scene-{NN}-{slug}.gif" \
   -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
   -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
   public/clips/scene-{NN}-{slug}.mp4
 
 # 4. Verify — fail closed (fall back to authored-terminal) if the MP4 is bad.
-#    Expect ~30 × duration frames, not 2–4 sparse ones.
-ffprobe -v error -count_frames -select_streams v:0 \
-  -show_entries stream=nb_read_frames,avg_frame_rate -of default=noprint_wrappers=1 \
+#    Expect ~30 × duration frames, not 2–4 sparse ones. nb_frames comes from the
+#    container header ffmpeg just wrote — no need for a full -count_frames decode.
+ffprobe -v error -select_streams v:0 \
+  -show_entries stream=nb_frames,avg_frame_rate -of default=noprint_wrappers=1 \
   public/clips/scene-{NN}-{slug}.mp4
 ```
 
@@ -136,10 +151,15 @@ window for brand parity with browser-mockup scenes. Animate the
   6s scene shouldn't record 60s of footage — pick `timeout = scene_duration + 2s`).
 - *Commands needing piped input.* Use `--command "bash -c '...'"` with a
   here-doc or `printf ... | <cmd>` inside. asciinema records the resulting PTY.
+- *Commands needing secrets.* Inject only the needed variable into the
+  scrubbed env (`env -i ... DEPLOY_TOKEN="$DEPLOY_TOKEN" asciinema rec ...`) —
+  see the pattern doc's edge-case matrix; never drop `env -i` wholesale.
 - *TTY allocation failure in the sandbox.* If `asciinema rec` errors with
-  *"could not allocate pty"*, the skill falls back to `script -qc "<cmd>" /dev/null`
-  and converts the typescript via a stub cast header — documented in the
-  pattern doc. If that also fails, fall back to the authored-terminal path.
+  *"could not allocate pty"*, the skill falls back to `script`:
+  GNU/Linux `script -qc "<cmd>" /dev/null` · BSD/macOS `script -q /dev/null <cmd>`
+  (BSD `script` has no `-c`), then converts the typescript via a stub cast
+  header — documented in the pattern doc. If that also fails, fall back to the
+  authored-terminal path.
 - *agg always emits a GIF (it ignores the output extension) with change-only
   frames.* That's why step 3's ffmpeg normalize is mandatory — not an older-agg
   special case: it rebuilds a constant 30fps timeline so seek-driven `<video>`
@@ -253,7 +273,7 @@ A rejected clip falls back to a screenshot or a re-record.
   }
   ```
 - **Dark mode (media-query apps)** — If the app reads `prefers-color-scheme`, use `mcp__chrome-devtools__emulate` with `colorScheme: "dark"`
-- **Dark mode (class-based / Tailwind `.dark`)** — `colorScheme` does nothing for apps that toggle a `.dark` class (most Next.js / shadcn). A one-shot injected class is **clobbered by SPA hydration** (React re-renders the root and overwrites it); an init-script loses the same race. Inject a `MutationObserver` via `evaluate_script` *before* navigating, so the class is re-added every time hydration strips it:
+- **Dark mode (class-based / Tailwind `.dark`)** — `colorScheme` does nothing for apps that toggle a `.dark` class (most Next.js / shadcn). A one-shot injected class is **clobbered by SPA hydration** (React re-renders the root and overwrites it). Inject a `MutationObserver` via `evaluate_script` **after `navigate_page` completes** — the observer re-adds the class every time hydration strips it (hydration re-renders don't navigate, so the observer survives them). Order matters: `evaluate_script` runs in the current document only, and any navigation wipes the page's JS context — an observer injected *before* navigating is destroyed by the navigation itself. Re-inject after every `navigate_page`:
   ```javascript
   () => {
     const html = document.documentElement;

--- a/workflows/phase-2-capture.md
+++ b/workflows/phase-2-capture.md
@@ -59,53 +59,76 @@ storyboard's intent and what's installed.
 3. This is an authored **scene** (not a clip) — it composes like any Phase-3 scene; no
    `public/clips/` file is produced. It is deterministic and on-brand.
 
-**Recommended for motion-heavy CLI — true real-time recording with `asciinema` + `agg`:**
+**Recommended for motion-heavy CLI — autonomous real-time recording with `asciinema` + `agg`:**
 
 Use this when the *motion is the point* (streaming build logs, spinners,
 TUIs like `lazygit`/`htop`, an interactive prompt). For full guidance —
-pre-flight, cast editing, theme/font choices, troubleshooting — see
+shell pre-flight, cast editing, theme/font choices, troubleshooting — see
 [`patterns/cli-terminal-capture.md`](../patterns/cli-terminal-capture.md).
 
-Quick path (only when both `asciinema` and `agg` are on PATH; otherwise fall
-back to the authored-terminal path):
+**The skill drives `asciinema` itself via the Bash tool — the user does NOT
+open a terminal or run anything by hand.** This works because
+`asciinema rec --command "<cmd>"` is non-interactive: asciinema allocates
+its own PTY, runs the command headless, captures stdout/stderr/timing,
+and exits when the command exits. Wrap in `timeout` so a runaway or
+non-terminating command (`htop`, dev server) can't stall the phase.
 
-1. **Prep the shell.** Open a clean terminal, set a minimal prompt, scrub
-   secrets from the environment, resize to 144×32:
-   ```bash
-   unset HISTFILE
-   export PS1='$ '
-   printf '\e[8;32;144t'
-   ```
-2. **Record.** `--idle-time-limit` collapses dead air — without it most
-   `npm install` clips are 90% waiting frames:
-   ```bash
-   asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 \
-     --command "<cmd>" cast.cast
-   ```
-3. **(Optional) Edit the cast.** The `.cast` is line-delimited JSON
-   (`[time, "o", "text"]`). Trim the tail, redact strings, or speed up
-   sections by halving `time` values. See the pattern doc.
-4. **Render to MP4.**
-   ```bash
-   agg --cols 144 --rows 32 --font-size 28 --theme monokai --fps-cap 30 \
-     cast.cast public/clips/scene-{NN}-{slug}.mp4
-   ```
-   If `agg` outputs only GIF on this host (older versions), pipe through
-   ffmpeg with `-vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" -pix_fmt yuv420p`
-   to land on an even-dimension H.264 MP4.
-5. **Compose** the scene from `templates/scene-terminal-clip.html` into
-   `scenes/{NN}-terminal-clip.html` — it wraps the MP4 in a macOS-style
-   window for brand parity with browser-mockup scenes. Animate the
-   `.term-frame` wrapper, never the `<video>` itself.
-6. **Verify** the file exists, is non-empty, and `ffprobe` reports a sane
-   duration. The Footage-quality gate (below) applies — bonus checks:
-   font ≥ 24px effective, no prompt cruft (`(venv)`, oh-my-zsh git status),
-   no idle gaps > 1s, theme contrast matches the scene background.
+Preconditions (silently fall back to the authored-terminal path if any fail):
+- `command -v asciinema && command -v agg` both succeed
+- The scene's storyboard entry has `Capture: terminal-clip` AND a `Command:` field
+  with the exact shell command to record
 
-If either tool is missing, do **not** prompt the user to install — fall back
-to the authored-terminal path and tell them once: *"asciinema/agg not
-detected — using the authored terminal scene. Install with `brew install
-asciinema agg` to record real terminal motion."*
+Autonomous sequence the skill executes (no user input between steps):
+
+```bash
+# 1. Record — non-interactive, PTY-isolated, timeout-bounded.
+#    --idle-time-limit collapses dead air (npm install would be 90% waiting otherwise).
+#    PS1='$ ' is exported into the child PTY so the prompt is brand-clean.
+#    HISTFILE unset and a sub-env keeps stray secrets out of the recording.
+timeout 60s env -i HOME="$HOME" PATH="$PATH" SHELL=/bin/bash PS1='$ ' \
+  asciinema rec --cols 144 --rows 32 --idle-time-limit 1.5 \
+    --command "<cmd-from-storyboard>" \
+    public/clips/scene-{NN}-{slug}.cast \
+  || true   # exit 124 (timeout) is non-fatal — the cast up to that point is valid
+
+# 2. Render the cast to MP4 — also autonomous; no user input.
+agg --cols 144 --rows 32 --font-size 28 --theme monokai --fps-cap 30 \
+  public/clips/scene-{NN}-{slug}.cast \
+  public/clips/scene-{NN}-{slug}.mp4
+
+# 3. Verify — fail closed (fall back to authored-terminal) if the MP4 is bad.
+ffprobe -v error -show_entries format=duration -of csv=p=0 \
+  public/clips/scene-{NN}-{slug}.mp4
+```
+
+Then author the scene from `templates/scene-terminal-clip.html` into
+`scenes/{NN}-terminal-clip.html` — it wraps the MP4 in a macOS-style
+window for brand parity with browser-mockup scenes. Animate the
+`.term-frame` wrapper, never the `<video>` itself.
+
+**Edge cases the autonomous path handles:**
+
+- *Long-running / non-terminating commands.* `timeout 60s` bounds them; the
+  partial cast is still valid. Adjust the timeout per scene duration (a
+  6s scene shouldn't record 60s of footage — pick `timeout = scene_duration + 2s`).
+- *Commands needing piped input.* Use `--command "bash -c '...'"` with a
+  here-doc or `printf ... | <cmd>` inside. asciinema records the resulting PTY.
+- *TTY allocation failure in the sandbox.* If `asciinema rec` errors with
+  *"could not allocate pty"*, the skill falls back to `script -qc "<cmd>" /dev/null`
+  and converts the typescript via a stub cast header — documented in the
+  pattern doc. If that also fails, fall back to the authored-terminal path.
+- *agg only outputs GIF on this host (older versions).* Pipe through ffmpeg
+  with `-vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" -pix_fmt yuv420p` to
+  land on an even-dimension H.264 MP4.
+
+The Footage-quality gate (below) still applies — bonus terminal-clip checks:
+font ≥ 24px effective, no prompt cruft, no idle gaps > 1s, theme contrast
+matches the scene background.
+
+If `asciinema` / `agg` are missing, do **not** prompt the user to install —
+fall back to the authored-terminal path and tell them once: *"asciinema/agg
+not detected — using the authored terminal scene. Install with
+`brew install asciinema agg` to enable autonomous terminal recording."*
 
 ## Step 2.1: Get App URL
 

--- a/workflows/phase-3-design.md
+++ b/workflows/phase-3-design.md
@@ -152,11 +152,15 @@ Transition pattern reference (when an archetype owns its own outgoing flourish):
 
 ### Clip scene (real footage)
 
-A clip scene is a normal sub-composition containing a **plain** `<video muted playsinline>`
-(Wiring S — render-verified). The runtime auto-discovers and frame-syncs the video to the
-scene's window; **do not** put `data-start`/`data-duration`/`data-track-index` on the `<video>`,
-and **never animate the `<video>` dimensions** — wrap it in a non-timed `.clip-frame` div and
-animate the wrapper. Copy `templates/scene-clip.html` as the starting point.
+A clip scene is a normal sub-composition containing a `<video muted playsinline>` that carries
+the explicit clip contract: `id`, `data-start="0"`, `data-duration` (= `(out-in)/speed`), and
+`data-track-index="0"`. The runtime frame-syncs the video's `currentTime` to this scene's window
+from those attributes (Wiring S — render-verified). **Do not omit them**: the runtime only seeks
+videos that carry `data-start`, so a bare `<video>` is displayed but never time-synced — safe only
+as the single clip in the whole composition, and with two or more clip scenes bare videos
+cross-route (one scene plays another's footage, another plays black). And **never animate the
+`<video>` dimensions** — wrap it in a non-timed `.clip-frame` div and animate the wrapper. Copy
+`templates/scene-clip.html` as the starting point.
 
 **Mandatory brand treatments** (so footage reads premium, not raw): device/browser frame +
 drop shadow, a vignette toward the brand canvas, a hidden OS cursor replaced by a brand-styled

--- a/workflows/phase-3-design.md
+++ b/workflows/phase-3-design.md
@@ -88,6 +88,7 @@ Request these scene archetypes (adapt to mode — promo or showcase):
 | `scenes/03-stat.html` | Animated counter + label, used for proof points |
 | `scenes/04-cta.html` | Call to action: headline, button, URL, brand sign-off |
 | `scenes/NN-clip.html` | Real footage clip framed in a device/browser frame with overlays |
+| `scenes/NN-terminal-clip.html` | asciinema/agg terminal footage in a macOS-style window (`templates/scene-terminal-clip.html`) |
 | `scenes/NN-recap.html` | **Tutorial-mode only** — chapter-summary recap beat (~90s segment cap) |
 
 Each scene template must:
@@ -153,14 +154,27 @@ Transition pattern reference (when an archetype owns its own outgoing flourish):
 ### Clip scene (real footage)
 
 A clip scene is a normal sub-composition containing a `<video muted playsinline>` that carries
-the explicit clip contract: `id`, `data-start="0"`, `data-duration` (= `(out-in)/speed`), and
+the explicit clip contract: `id`, `data-start="0"`, `data-duration`, `data-media-start`, and
 `data-track-index="0"`. The runtime frame-syncs the video's `currentTime` to this scene's window
-from those attributes (Wiring S — render-verified). **Do not omit them**: the runtime only seeks
+from those attributes (Wiring S — render-verified). Two values matter:
+
+- `data-duration` = the scene loader's **full** `data-duration` from `index.html` — i.e.
+  `(out-in)/speed` **plus the 0.4s crossfade extension** (Phase 4 Step 4.5 /
+  `patterns/transition-catalog.md`). If the video's track ends at the nominal clip length,
+  the runtime hides it (`visibility:hidden`) during the crossfade and the outgoing scene
+  shows an empty frame.
+- `data-media-start` = the storyboard's `Clip in` (trim offset into the source, seconds;
+  `0` if the whole clip is used). Without it the runtime plays from source `t=0`, the
+  `Clip in/out` trim is silently ignored, and the footage desyncs from Phase 5's
+  clip-audio extraction (`CIN`).
+
+**Do not omit the contract**: the runtime only seeks
 videos that carry `data-start`, so a bare `<video>` is displayed but never time-synced — safe only
 as the single clip in the whole composition, and with two or more clip scenes bare videos
 cross-route (one scene plays another's footage, another plays black). And **never animate the
 `<video>` dimensions** — wrap it in a non-timed `.clip-frame` div and animate the wrapper. Copy
-`templates/scene-clip.html` as the starting point.
+`templates/scene-clip.html` as the starting point (`templates/scene-terminal-clip.html` for
+asciinema/agg terminal footage).
 
 **Mandatory brand treatments** (so footage reads premium, not raw): device/browser frame +
 drop shadow, a vignette toward the brand canvas, a hidden OS cursor replaced by a brand-styled

--- a/workflows/phase-3-design.md
+++ b/workflows/phase-3-design.md
@@ -123,7 +123,7 @@ Each scene template must:
       [data-composition-id="scene-00-title-card"] #subtitle { font-size: 44px; margin-top: 24px; }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
     <script>
       window.__timelines = window.__timelines || {};
       const tl = gsap.timeline({ paused: true });

--- a/workflows/phase-4-production.md
+++ b/workflows/phase-4-production.md
@@ -153,7 +153,7 @@ Screenshots stay at `public/screenshots/` — referenced from `index.html` via r
     <!-- … etc … -->
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js" integrity="sha384-sG0Hv1tP1lZCk9KQmrIbY/XNwi+OY84GQqhMscbnsoBFqAz8KNCil1kvfL3Hbbk2" crossorigin="anonymous"></script>
   <script>
     // The root composition needs a registered timeline too, even if it only
     // hosts inter-scene transitions and ambient effects.

--- a/workflows/phase-4-production.md
+++ b/workflows/phase-4-production.md
@@ -191,10 +191,17 @@ Use the `hyperframes` skill for the composition authoring rules — the most imp
   scene window from the footage — do **not** stretch a clip scene to fit VO; VO
   is written to fit the footage-derived window in Phase 5.
 - **Each clip scene's inner `<video>` carries its own timing** — `id` + `data-start="0"`
-  + `data-duration` (= the clip's on-screen length) + `data-track-index="0"`. The runtime
+  + `data-duration` + `data-media-start` + `data-track-index="0"`. The runtime
   only frame-syncs videos that have `data-start`; without it the clip isn't synced and, with
   2+ clip scenes, cross-routes (one scene plays another's footage, another plays black). The
   `scene-clip.html` / `scene-terminal-clip.html` archetypes pre-wire this — keep it.
+  - The inner video's `data-duration` = the **loader's full window incl. the 0.4s crossfade
+    extension** (Step 4.5), NOT the bare clip length — the runtime hides an expired track
+    (`visibility:hidden`), so a video that ends at the nominal length blanks the frame during
+    every crossfade out of the scene.
+  - `data-media-start` = the storyboard's `Clip in` (trim offset, seconds; `0` if whole).
+    Omitting it plays the source from `t=0`, discards the `Clip in/out` trim, and desyncs the
+    footage from Phase 5's clip-audio window (`CIN`/`COUT`, Step 5.3a).
 - A rigid real-time clip (e.g. a live command run) sets its own budget: keep it at
   `Speed: 1.0` and size the scene to the real length; speed-ramp **only** explicitly
   marked dead air.

--- a/workflows/phase-4-production.md
+++ b/workflows/phase-4-production.md
@@ -190,6 +190,11 @@ Use the `hyperframes` skill for the composition authoring rules — the most imp
   `(out − in) / speed` (from the storyboard `Clip in/out` + `Speed`). Set the
   scene window from the footage — do **not** stretch a clip scene to fit VO; VO
   is written to fit the footage-derived window in Phase 5.
+- **Each clip scene's inner `<video>` carries its own timing** — `id` + `data-start="0"`
+  + `data-duration` (= the clip's on-screen length) + `data-track-index="0"`. The runtime
+  only frame-syncs videos that have `data-start`; without it the clip isn't synced and, with
+  2+ clip scenes, cross-routes (one scene plays another's footage, another plays black). The
+  `scene-clip.html` / `scene-terminal-clip.html` archetypes pre-wire this — keep it.
 - A rigid real-time clip (e.g. a live command run) sets its own budget: keep it at
   `Speed: 1.0` and size the scene to the real length; speed-ramp **only** explicitly
   marked dead air.
@@ -233,6 +238,19 @@ All gates take the project **directory** (they resolve `index.html` inside it), 
 `--samples` controls how many timestamps `inspect` seeks to. Typical convention: `--samples 10` for 30s spots, `--samples 15` for denser transition-heavy cuts. Use `--at 1.5,4,7.25` instead if you want to audit specific hero frames.
 
 All three must pass cleanly (or report only overflows you've consciously marked intentional).
+
+### Hero-frame content check (mandatory — gates can't see "wrong content")
+
+`lint`, `inspect`, and `validate` are mechanical: structure, layout overflow, contrast. **None of them judges whether each scene is showing the *right* content** — a clip wired to the wrong footage or a stale `<img src>` passes all three GREEN (this is exactly how the bare-`<video>` clip cross-route shipped unnoticed). Catch it here, cheaply, *before* the full render in Phase 5.
+
+Re-run `inspect` at the **midpoint of each scene** (not a uniform sweep) so every scene contributes one readable hero frame:
+
+```bash
+# Midpoints from the storyboard scene windows, e.g. scene 0 spans 0–5 → 2.5, etc.
+npx hyperframes inspect . --at 2.5,7,12,18,24,30
+```
+
+Then **Read each `.hyperframes/inspect/*.png`** and confirm, scene by scene, that the frame shows what the storyboard calls for — correct screenshot, correct clip footage, correct copy. This re-uses the headless-Chrome frames `inspect` already writes (no `ffmpeg`, no rendered MP4 needed — the render doesn't exist until Phase 5). Do not advance until every scene's hero frame matches its storyboard intent.
 
 Ask:
 

--- a/workflows/phase-5-audio.md
+++ b/workflows/phase-5-audio.md
@@ -296,7 +296,8 @@ clip path (`Clip:`), the scene `data-start` (`CW`, from index.html), `Clip in/ou
 
 ```bash
 CLIP=public/clips/scene-03-demo.mp4       # storyboard `Clip:`
-CIN=2.0 ; COUT=8.0 ; SPEED=1.0            # `Clip in/out` + `Speed`
+CIN=2.0 ; COUT=8.0 ; SPEED=1.0            # `Clip in/out` + `Speed` — CIN must equal the
+                                           # scene <video>'s data-media-start or A/V desync
 CW=18.5                                    # scene data-start in index.html
 VOL=0.6                                    # `Clip audio` value
 DELAY=$(echo "$CW*1000/1" | bc)

--- a/workflows/phase-5-audio.md
+++ b/workflows/phase-5-audio.md
@@ -55,7 +55,7 @@ When a section overruns budget, **drop commas before dropping words**. Restructu
 
 Each comma you remove saves ~0.3–0.5s. A 5-comma rewrite can reclaim 2+ seconds without cutting meaning.
 
-`scripts/generate_voiceover.py` catches this for you at assembly time: when a section's audio overruns its slot it prints `WARNING: section N audio overruns its Xs slot by Ys — every later section starts early and desyncs from its scene` to stderr. **Watch stderr** — a single overrun cascades into every later section, so fix the flagged one (drop commas first) and re-run before moving on.
+`scripts/generate_voiceover.py` catches this for you at assembly time: when a section's audio overruns its slot it prints a stderr warning like `WARNING: section N audio overruns its Xs slot by Ys — every later section starts early and desyncs from its scene. Shorten this section's text.` **Watch stderr** — a single overrun cascades into every later section, so fix the flagged one (drop commas first) and re-run before moving on.
 
 ### Clip scenes and VO timing
 

--- a/workflows/phase-5-audio.md
+++ b/workflows/phase-5-audio.md
@@ -55,6 +55,8 @@ When a section overruns budget, **drop commas before dropping words**. Restructu
 
 Each comma you remove saves ~0.3–0.5s. A 5-comma rewrite can reclaim 2+ seconds without cutting meaning.
 
+`scripts/generate_voiceover.py` catches this for you at assembly time: when a section's audio overruns its slot it prints `WARNING: section N audio overruns its Xs slot by Ys — every later section starts early and desyncs from its scene` to stderr. **Watch stderr** — a single overrun cascades into every later section, so fix the flagged one (drop commas first) and re-run before moving on.
+
 ### Clip scenes and VO timing
 
 For clip scenes the scene window is footage-derived (Phase 4), not VO-derived.
@@ -143,8 +145,11 @@ Compare timestamps against scene timings. If ANY overlap detected:
 
 If the content-mode is `tutorial`, on-screen VO captions are **mandatory on every footage
 segment** (spec §7.2) and this **intentionally overrides** the default-optional policy in
-`patterns/INDEX.md`. Silence-only segments (no VO words in the window) are exempt; in
-promo/showcase captions stay optional.
+`patterns/INDEX.md`. Silence-only segments (no VO words in the window) are exempt, as are
+segments whose on-screen copy already renders the spoken line verbatim (e.g. a recap beat or
+step title card where the visible text IS the narration) — in that case mark `Captions: carried`
+on the storyboard scene so the skip is a recorded, deliberate choice rather than an oversight.
+In promo/showcase captions stay optional.
 
 Captions are a HyperFrames caption sub-comp synced to `transcript.json` — see
 `references/captions.md` (GROUPS mechanism) and the Phase-3 caption-track recipe. Each
@@ -153,7 +158,9 @@ its window in `index.html`.
 
 Orchestrator enforcement before render (tutorial mode) — do not advance until all hold:
 1. `transcript.json` exists and passed the timing check.
-2. Every footage scene with VO has a caption track (per the storyboard `Captions: auto` field).
+2. Every footage scene with VO has a caption track, UNLESS its storyboard marks `Captions: carried`
+   (on-screen copy already shows the spoken line) or the window is silence-only. A bare
+   `Captions: auto` scene with VO and no track still blocks.
 3. Each caption group has a hard `tl.set(... {opacity:0, visibility:"hidden"}, group.end)` kill
    (the `references/captions.md` `[caption-lint]` self-check logs warnings otherwise).
 There is no programmatic gate; a true build-time rule would be upstream `hyperframes` lint work (spec §14).


### PR DESCRIPTION
## Summary

Release **v0.0.3** of the `hve-spielberg` skill. Two main thrusts:

1. **Autonomous asciinema + agg CLI recording** (`feat(capture)`) — terminal scenes are now captured by the skill itself via `asciinema rec --command`, PTY-isolated, env-scrubbed, and timeout-bounded; `agg` + ffmpeg normalize the cast into a constant-fps MP4. New `patterns/cli-terminal-capture.md` end-to-end guide, new `templates/scene-terminal-clip.html` archetype (macOS-window-framed terminal footage), new `Capture: terminal-clip` + `Command:` + `Record timeout:` storyboard fields. Falls back silently to the authored-terminal path when asciinema/agg are missing.
2. **Explicit clip `<video>` timing contract** (`fix(clips)`) — clip scenes previously used a bare `<video>`; the renderer only seeks videos carrying `data-start`, so with 2+ clip scenes footage cross-routed while all gates passed green. Both clip templates and the phase-3/4 docs now mandate `id` + `data-start="0"` + `data-duration` + `data-track-index="0"`, plus a mandatory hero-frame content check in Phase 4.

Also: `SKILL.md` frontmatter gains `Bash(asciinema:*), Bash(agg:*), Bash(timeout:*), Bash(ffprobe:*)`; version bumped to 0.0.3; CHANGELOG entry added.

## Commits

- `7c5b98f` feat(capture): add professional asciinema + agg CLI recording path
- `77c078d` docs(skill): broaden Phase 2 capability description to multi-source capture
- `929d1cf` feat(capture): make asciinema run autonomously via the skill's Bash tool
- `6e8f2cc` chore(release): bump skill to v0.0.3 — autonomous asciinema capture
- `13ce902` fix(clips): bind clip `<video>` via explicit timing contract

## Pre-merge review findings (high-effort, verified against the HyperFrames 0.6.42 runtime)

Correctness — worth fixing before or shortly after merge:

1. **`Clip in/out` trim is silently dropped.** The new clip contract has no attribute for the source trim offset; HyperFrames defines `data-media-start` for exactly this (runtime computes `mediaTime = (t − start) · rate + mediaStart`). A `Clip in/out: 2s–8s` scene shows source 0–6s, desynced from Phase 5's `CIN=2.0` clip-audio extraction. (`templates/scene-clip.html`, `phase-3-design.md`, `phase-4-production.md`)
2. **Clip blanks during every crossfade.** `transition-catalog.md` extends each scene's window 0.4s for crossfade overlap, but the inner video's `data-duration` is set to the nominal clip length — the runtime sets `visibility:hidden` past track end, so the outgoing clip scene renders an empty frame during the 0.4s crossfade. The inner video's `data-duration` needs the same +0.4s extension.
3. **Phase 1 can never produce `Capture: terminal-clip`.** `phase-1-storytelling.md` § "Capture type per scene" still enumerates only `screencast | terminal | supplied` and never mentions `Command:`/`Record timeout:` — in `new` mode the headline feature is unreachable and Phase 2 silently falls back every time.
4. **`env -i` kills asciinema 2.x.** The record command scrubs `LANG`/`LC_ALL`; asciinema 2.x (the apt install path the docs recommend) aborts with "needs a UTF-8 native locale", and `|| true` swallows it. Pass `LANG=C.UTF-8` through `env -i`.
5. **Record/render size mismatch.** Cast is recorded at `COLUMNS=175` but rendered with `agg --cols 144` — the pattern doc's own troubleshooting row says these must match; wide output (the reason 175 was chosen) wraps/letterboxes.
6. **Dark-mode MutationObserver instruction is inverted.** `evaluate_script` runs in the current document; `navigate_page` destroys it. Injecting "*before* navigating" (phase-2-capture.md:256) does nothing — inject after navigation (the observer then survives hydration, which doesn't navigate).
7. **`timeout` not feature-detected.** GNU `timeout` is absent on stock macOS (brew installs only asciinema/agg); preconditions probe only `asciinema`/`agg`, and `|| true` masks `command not found`, surfacing as a confusing agg missing-input error instead of a clean fallback.
8. **`script -qc` fallback is GNU-only and unauthorized.** BSD/macOS `script` has no `-c`, and `Bash(script:*)` is not in `allowed-tools` — the PTY-failure fallback dead-ends on the platform the README leads with.
9. **`mcp__chrome-devtools__emulate` missing from `allowed-tools`** despite three phase-2 instructions using it (viewport emulation + the new dark-mode bullet).
10. **`transition-catalog.md:63` now contradicts the clip contract** ("Only the root composition gets `data-start`/`data-duration`") — a future session following the catalog may strip the video attributes and reintroduce the cross-route bug.

Lower-priority notes: the 0.0.3 CHANGELOG entry predates `13ce902` and omits the clip-contract fix; the bare-`<video>` rule isn't in the central `## DON'Ts` lists; `phase-3-design.md`'s archetype table doesn't list `scene-terminal-clip.html`; the autonomous bash sequence + clip contract + install commands are each duplicated across 2–5 files (drift already visible: `--speed 1.0` present in one copy only, secrets edge-case missing from the workflow copy); the intermediate GIF is left in `public/clips/`; `ffprobe -count_frames` full-decodes when a header read suffices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
