### PR TITLE
feat(audio): sidechain-duck music under the voiceover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **True-peak ceiling breach in the audio master.** The old `alimiter=limit=0.95`
-  could leave the final mix above the -1 dBTP target (measured -0.3 dBFS); the new
-  master lands well under it (~-3.8 dBFS). The Step 5.3a clip-audio re-master is
+  could leave the final mix above the -1 dBTP target (measured true peak -0.3 dBTP); the
+  new master lands well under it (~-3.8 dBTP). The Step 5.3a clip-audio re-master is
   aligned to the same ceiling.
 
 ## [0.0.3] - 2026-06-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Phase 5 music mix now sits the soundtrack under the voice as a ducked bed.**
+  The static `volume=0.22` blend in `workflows/phase-5-audio.md` is replaced with:
+  music normalized to a known base (`loudnorm I=-30`), EQ space carved for speech
+  (`highpass=100` + `-3 dB @ 2.5 kHz`), and **sidechain ducking** keyed off the
+  voiceover so the music dips under speech and breathes back in the gaps. Mastered
+  with a peak limiter (`alimiter`, ~-1 dBFS) while the voiceover's -16 LUFS
+  normalization carries loudness — a dynamic `loudnorm` master was rejected
+  because it rides gain and reverses the duck. `aresample` guards keep
+  mismatched-rate sources working through `amix`. `example/README.md` updated to
+  match.
+
+### Fixed
+
+- **True-peak ceiling breach in the audio master.** The old `alimiter=limit=0.95`
+  could leave the final mix above the -1 dBTP target (measured -0.3 dBFS); the new
+  master lands well under it (~-3.8 dBFS). The Step 5.3a clip-audio re-master is
+  aligned to the same ceiling.
+
 ## [0.0.3] - 2026-06-08
 
 Added a professional, skill-driven asciinema + agg CLI recording path so

--- a/example/README.md
+++ b/example/README.md
@@ -23,7 +23,7 @@ Every *input* artifact lives in this directory — it's the project's primary de
 | `voiceover.py` | 5 | ElevenLabs TTS (Matilda) + `npx hyperframes transcribe` verification + auto-pad to VIDEO_DURATION |
 | `voiceover.mp3` | 5 | Generated 60s voiceover (5 sections with silence padding) — gitignored, regenerable |
 | `background-music.mp3` | 5 | "Unpretentious Reveal" by SondreDrakensson (Freesound, CC-BY) — gitignored, fetch via Step 5.2 |
-| `voiceover-with-music.mp3` | 5 | ffmpeg-mixed final audio with loudnorm + amix + alimiter — gitignored, regenerable |
+| `voiceover-with-music.mp3` | 5 | ffmpeg-mixed final audio: music normalized + EQ'd + sidechain-ducked under the voice, peak-limited to ≈-1 dBFS (lands ≈-16 LUFS) — gitignored, regenerable |
 | `out/final.mp4` | 5 | **The rendered video.** `npx hyperframes render` output — not committed; regenerable build artifact (watch the demo on YouTube, or regenerate with the steps below). |
 | `CREDITS.md` | — | CC-BY attribution for the music track + voiceover provenance |
 
@@ -57,9 +57,13 @@ ffmpeg -y -i voiceover.mp3 \
   voiceover-normalized.mp3
 ffmpeg -y -i voiceover-normalized.mp3 -i background-music.mp3 \
   -filter_complex "
-    [1:a]atrim=0:60,volume=0.22,afade=t=in:st=0:d=2,afade=t=out:st=57:d=3[music];
-    [0:a][music]amix=inputs=2:duration=first:dropout_transition=0:normalize=0,
-                alimiter=limit=0.95[out]" \
+    [1:a]atrim=0:60,loudnorm=I=-30:TP=-3:LRA=11,
+         highpass=f=100,equalizer=f=2500:t=q:w=1:g=-3,
+         afade=t=in:st=0:d=2,afade=t=out:st=56:d=4,aresample=44100[music];
+    [0:a]aresample=44100,asplit=2[vo][key];
+    [music][key]sidechaincompress=threshold=0.05:ratio=3:attack=150:release=900[ducked];
+    [vo][ducked]amix=inputs=2:duration=first:dropout_transition=0:normalize=0,
+                alimiter=limit=0.89,aresample=44100[out]" \
   -map "[out]" -c:a libmp3lame -q:a 2 voiceover-with-music.mp3
 
 # 5. Run quality gates + render

--- a/workflows/phase-5-audio.md
+++ b/workflows/phase-5-audio.md
@@ -247,25 +247,64 @@ ffmpeg -y -i voiceover.mp3 -af "loudnorm=I=-16:TP=-1.5:LRA=11" voiceover-normali
 
 ### Mix music (if using background music)
 
+The music is a **subtle bed under the voice**, not a soundtrack — it should be *felt more than
+heard* while words play, and only noticeable in its absence. Three things make it behave:
+(1) normalize the music to a **known base level** so the balance doesn't depend on how hot the
+source file happens to be, (2) **EQ space** around the voice, and (3) **sidechain-duck the music
+under the voiceover** so it dips while words play and breathes back in the gaps.
+
 ```bash
-# DURATION = video length in seconds (from Phase 1 / project-plan.md);
-# FADE_OUT_START = DURATION - 3
+# DURATION = video length in seconds (from Phase 1 / project-plan.md).
+# Fade-out runs 4s (3–5s is the polished range); never cut the music abruptly.
 DURATION=60                                # ← replace with your video duration
-FADE_OUT_START=$((DURATION - 3))
+FADE_OUT_START=$((DURATION - 4))
 
 ffmpeg -y -i voiceover-normalized.mp3 -i background-music.mp3 \
   -filter_complex "
     [1:a]atrim=0:${DURATION},
-         volume=0.22,
+         loudnorm=I=-30:TP=-3:LRA=11,
+         highpass=f=100,
+         equalizer=f=2500:t=q:w=1:g=-3,
          afade=t=in:st=0:d=2,
-         afade=t=out:st=${FADE_OUT_START}:d=3[music];
-    [0:a][music]amix=inputs=2:duration=first:dropout_transition=0:normalize=0,
-                alimiter=limit=0.95[out]" \
+         afade=t=out:st=${FADE_OUT_START}:d=4,
+         aresample=44100[music];
+    [0:a]aresample=44100,asplit=2[vo][key];
+    [music][key]sidechaincompress=threshold=0.05:ratio=3:attack=150:release=900[ducked];
+    [vo][ducked]amix=inputs=2:duration=first:dropout_transition=0:normalize=0,
+                alimiter=limit=0.89,
+                aresample=44100[out]" \
   -map "[out]" -c:a libmp3lame -q:a 2 \
   voiceover-with-music.mp3
 ```
 
-**Critical:** `amix` defaults to `normalize=1`, which divides each input by the number of inputs (a hidden -6dB on every track). With music already attenuated to 0.22, that double-cut leaves music near-inaudible. Always pass `normalize=0` and rely on `alimiter` for peak control.
+What each stage does — tune by ear, the numbers are starting points, not targets:
+
+- **`loudnorm=I=-30` (music base level)** — normalizes the bed to ~-30 LUFS, ~14 LU under the
+  -16 LUFS voice, so the mix no longer depends on the track's mastered level. This replaces the
+  old fixed `volume=0.22`, which scaled an *un-normalized* download and gave unpredictable
+  loudness. If the music vanishes under speech, raise toward -28/-26; if it competes, lower toward -32.
+- **`highpass=f=100` + `equalizer=f=2500…g=-3` (music EQ)** — strips sub-100 Hz rumble (product
+  demos rarely need deep bass) and dips ~3 dB around 2.5 kHz to carve room for speech clarity.
+- **`sidechaincompress` keyed by the voice (`[key]`)** — the core move: the music ducks ~3–6 dB
+  whenever the voiceover plays (attack 150 ms, release 900 ms = smooth, not pumping) and returns
+  in pauses. Same filter the clip-audio path uses in Step 5.3a, here applied to the *music* with
+  the *voice* as the trigger. If it pumps, lower `ratio` or lengthen `release`; if the first
+  words are masked, drop `attack` toward 100.
+- **`alimiter=limit=0.89` (master ≈ -1 dBFS ceiling)** — a peak limiter, *not* a loudness
+  normalizer. The voiceover is already at -16 LUFS (normalize step) and dominates the mix, so a
+  -30 LUFS bed only nudges integrated loudness ~+0.2 LU — the mix lands ≈-15.8 LUFS on its own,
+  in-spec. This matches the guide's master chain ("limiter, ceiling -1 dB").
+  **Do not add a dynamic `loudnorm` master here.** Single-pass `loudnorm` rides gain, so it boosts
+  the bed in the intro, outro, and every VO pause (chasing -16 when only the quiet music is present),
+  which *undoes the sidechain duck and fights the fades* — verified: with a dynamic master the music
+  measures **louder** under speech than in the gaps. If you need to hit -16 LUFS more exactly,
+  correct with a **constant** gain after validation (below), never a dynamic pass.
+- **`aresample=44100`** — the music-branch `loudnorm` can internally switch to 192 kHz; the explicit
+  resamples keep the `sidechaincompress`/`amix` inputs rate-matched and the MP3 encoder happy.
+
+**Critical:** keep `amix … normalize=0`. The default `normalize=1` divides each input by the input
+count (a hidden -6 dB per track), which would gut the already-quiet bed. Set level via the music
+base (`loudnorm=I=-30`) plus the VO's own -16 LUFS normalization, not `amix` normalization.
 
 ### No-music path (voiceover only)
 
@@ -283,10 +322,20 @@ cp voiceover-normalized.mp3 voiceover-with-music.mp3
 
 Then proceed to Step 5.4 — the render step doesn't care whether music was mixed in or not, as long as `voiceover-with-music.mp3` exists and is the full composition duration.
 
-Validate with `ebur128`: integrated loudness should land around -16 LUFS, true peak under -0.5 dBFS.
+Validate with `ebur128`: integrated loudness should land around -16 LUFS, true peak at or under -1 dBTP.
 
 ```bash
 ffmpeg -hide_banner -i voiceover-with-music.mp3 -af ebur128=peak=true -f null - 2>&1 | tail -16
+```
+
+If integrated loudness lands outside -16 ±1.5 LUFS (e.g. a sparse, pause-heavy VO drags it low),
+nudge it with a **constant** gain — `volume=<delta>dB` shifts the whole mix uniformly, so it
+preserves the duck and the fades, unlike a dynamic `loudnorm` — then re-cap the peak:
+
+```bash
+ffmpeg -y -i voiceover-with-music.mp3 -af "volume=1.5dB,alimiter=limit=0.89" \
+  -c:a libmp3lame -q:a 2 voiceover-with-music.fixed.mp3
+mv voiceover-with-music.fixed.mp3 voiceover-with-music.mp3
 ```
 
 ## Step 5.3a: Clip-own audio (opt-in)
@@ -314,7 +363,7 @@ ffmpeg -y -i voiceover-with-music.mp3 -i clip-audio-03.mp3 \
     [1:a]asplit=2[clip][key];
     [0:a][key]sidechaincompress=threshold=0.05:ratio=8:attack=20:release=300[ducked];
     [ducked][clip]amix=inputs=2:duration=first:dropout_transition=0:normalize=0,
-                  alimiter=limit=0.95[out]" \
+                  alimiter=limit=0.89[out]" \
   -map "[out]" -c:a libmp3lame -q:a 2 voiceover-with-music.tmp.mp3
 mv voiceover-with-music.tmp.mp3 voiceover-with-music.mp3
 ```
@@ -323,7 +372,7 @@ Repeat per opt-in clip (each pass overwrites the canonical file). Re-validate:
 ```bash
 ffmpeg -hide_banner -i voiceover-with-music.mp3 -af ebur128=peak=true -f null - 2>&1 | tail -16
 ```
-Expected: integrated loudness ≈ -16 LUFS, true peak < -0.5 dBFS; the ducked window is audibly quieter under the clip's sound.
+Expected: integrated loudness ≈ -16 LUFS, true peak at or under -1 dBTP; the ducked window is audibly quieter under the clip's sound.
 
 ## Step 5.4: Final Render
 

--- a/workflows/phase-5-audio.md
+++ b/workflows/phase-5-audio.md
@@ -322,7 +322,7 @@ cp voiceover-normalized.mp3 voiceover-with-music.mp3
 
 Then proceed to Step 5.4 — the render step doesn't care whether music was mixed in or not, as long as `voiceover-with-music.mp3` exists and is the full composition duration.
 
-Validate with `ebur128`: integrated loudness should land around -16 LUFS, true peak at or under -1 dBTP.
+Validate with `ebur128`: integrated loudness should land around -16 LUFS, and the reported true peak should come in at or under -1 dBTP. `alimiter` caps *sample* peaks, not inter-sample/true peaks, so treat -1 dBTP as a target to **verify** — if `ebur128` reports a true peak above -1 dBTP, lower the Step 5.3 limiter ceiling (e.g. `alimiter=limit=0.79`, ≈ -2 dBFS) and re-render.
 
 ```bash
 ffmpeg -hide_banner -i voiceover-with-music.mp3 -af ebur128=peak=true -f null - 2>&1 | tail -16
@@ -372,7 +372,7 @@ Repeat per opt-in clip (each pass overwrites the canonical file). Re-validate:
 ```bash
 ffmpeg -hide_banner -i voiceover-with-music.mp3 -af ebur128=peak=true -f null - 2>&1 | tail -16
 ```
-Expected: integrated loudness ≈ -16 LUFS, true peak at or under -1 dBTP; the ducked window is audibly quieter under the clip's sound.
+Expected: integrated loudness ≈ -16 LUFS, with true peak at or under -1 dBTP; the ducked window is audibly quieter under the clip's sound. As in Step 5.3, `alimiter` caps sample peaks — verify the true peak with `ebur128` and lower the limiter ceiling if it reports above -1 dBTP.
 
 ## Step 5.4: Final Render
 


### PR DESCRIPTION
## What & why

Phase 5 currently blends background music into the voiceover at a **static** level
(`volume=0.22`) with no EQ and no ducking, so the music sits at one fixed level under
*and* between spoken words. This reworks the Step 5.3 mix to follow standard
voice-over-under-music practice for product demos — the music becomes a **subtle bed
that ducks under the voice and breathes back in the gaps**.

**Changes**
- Normalize the music to a known base (`loudnorm I=-30`) instead of scaling an
  un-normalized download, so the balance no longer depends on the source track's level.
- Carve EQ room for speech: `highpass=100` + a `-3 dB` dip at `2.5 kHz`.
- **Sidechain-duck** the music, keyed off the voiceover (the core technique).
- Master with a peak limiter (`alimiter`, ~`-1 dBFS`); the voiceover's existing
  `-16 LUFS` normalization carries loudness. A dynamic `loudnorm` master was **rejected**:
  it rides gain and *reverses* the duck (boosts the bed in pauses/intro/outro). Verified
  below.
- `aresample` guards keep mismatched-rate sources working through `amix`.
- Aligns the Step 5.3a clip-audio re-master to the same `-1 dBTP` ceiling and updates
  `example/README.md` to match.

Files: `workflows/phase-5-audio.md`, `example/README.md`, `CHANGELOG.md`.

## Evidence it works

Built from **one real spoken voiceover** (with silence gaps) + the skill's own example
music track ("Unpretentious Reveal", Freesound CC-BY), run through the **old** chain and
the **new** chain.

### 1. Sidechain ducking (the headline)

Per-0.5 s level of the voice (blue), the BEFORE bed (grey) and the AFTER bed (green).
The green bed dips ~8–12 dB under every speech burst and rises back in the shaded silence
gaps; the grey bed is flat regardless of the voice.

![Sidechain ducking — AFTER bed dips under speech, BEFORE is flat](https://raw.githubusercontent.com/ncksol/hve-spielberg/pr-evidence/evidence/CHART-ducking.png)

Isolated music bed, mean dB (VO silence gaps at ~1 s / 7 s / 13 s / 19 s):

| second | voice | BEFORE bed | AFTER bed |
|---:|---:|---:|---:|
| 1 s (gap)    | −76.9 | −35.9 | −38.1 |
| 4 s (speech) | −15.8 | −31.4 | **−43.3** |
| 7 s (gap)    | −83.3 | −30.6 | −34.8 |
| 10 s (speech)| −15.6 | −31.5 | **−43.9** |
| 13 s (gap)   | −83.3 | −32.3 | −35.9 |
| 17 s (speech)| −14.8 | −31.6 | **−44.6** |

BEFORE bed ≈ −31 dB whether speaking or not (no duck). AFTER bed ≈ −35 dB in gaps,
ducking to ≈ −44 dB under speech.

### 2. Loudness & true peak (`ffmpeg ebur128`)

| Mix | Integrated | True peak |
|---|---:|---:|
| BEFORE (`volume=0.22`, `alimiter=0.95`) | −15.9 LUFS | **−0.3 dBFS** — breaches the −1 dBTP target |
| AFTER (this PR) | −15.4 LUFS | **−3.8 dBFS** — compliant |

So the new master also **fixes a true-peak ceiling breach** in the old chain.

### 3. EQ carves space (isolated bed, mean dB)

| band | BEFORE | AFTER |
|---|---:|---:|
| sub-100 Hz (high-pass) | −34.6 | −41.2 |
| ~2.5 kHz (voice dip) | −56.6 | −59.5 |

### Reproduce

Take any `voiceover-normalized.mp3` (the Step 5.3 input, normalized to −16 LUFS) and any
music file, apply the **Step 5.3 recipe from this PR**, then:

```bash
ffmpeg -hide_banner -i voiceover-with-music.mp3 -af ebur128=peak=true -f null - 2>&1 | tail -16
```

Expect integrated ≈ −16 LUFS and true peak ≤ −1 dBTP. Full per-second analysis:
[`evidence/analysis.txt`](https://raw.githubusercontent.com/ncksol/hve-spielberg/pr-evidence/evidence/analysis.txt) ·
[waveform comparison](https://raw.githubusercontent.com/ncksol/hve-spielberg/pr-evidence/evidence/COMPARE-waveforms.png).

## Notes

- The evidence voiceover uses macOS `say`, so the **voice quality** isn't representative of
  an ElevenLabs render — but the **mix behaviour** (ducking, EQ, loudness, true peak) is
  exactly what the new chain produces.
- The embedded images live on a separate `pr-evidence` branch of my fork; they are **not**
  part of this PR's diff.
- No build/test/lint exists in the repo; validation is the ffmpeg measurements above.
