### PR TITLE
feat(skill): make the skill agent-agnostic (Copilot CLI + Claude Code)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "hve-spielberg",
+  "description": "AI-powered video production pipeline skill for Claude Code and GitHub Copilot CLI.",
+  "owner": {
+    "name": "Nebrass Lamouchi",
+    "email": "lnibrass@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "hve-spielberg",
+      "source": "./",
+      "description": "End-to-end video production pipeline with design thinking. A 6-phase orchestrator (Discovery → Storytelling → Capture → Design → Production → Audio & Render) that turns your app into a polished promo, showcase, or tutorial video, rendered with HyperFrames (HTML + GSAP). Runs on Claude Code and GitHub Copilot CLI.",
+      "version": "0.0.3",
+      "homepage": "https://github.com/nebrass/hve-spielberg",
+      "license": "MIT",
+      "author": {
+        "name": "Nebrass Lamouchi",
+        "email": "lnibrass@gmail.com"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "hve-spielberg",
+  "description": "End-to-end video production pipeline with design thinking. A 6-phase orchestrator (Discovery → Storytelling → Capture → Design → Production → Audio & Render) that turns your app into a polished promo, showcase, or tutorial video, rendered with HyperFrames (HTML + GSAP). Runs on Claude Code and GitHub Copilot CLI.",
+  "version": "0.0.3",
+  "author": {
+    "name": "Nebrass Lamouchi",
+    "email": "lnibrass@gmail.com"
+  },
+  "homepage": "https://github.com/nebrass/hve-spielberg",
+  "repository": "https://github.com/nebrass/hve-spielberg",
+  "license": "MIT",
+  "keywords": [
+    "video",
+    "promo",
+    "showcase",
+    "tutorial",
+    "hyperframes",
+    "gsap",
+    "elevenlabs",
+    "tts",
+    "storyboard",
+    "design-thinking",
+    "claude-code",
+    "github-copilot"
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,47 @@
+{
+  "name": "hve-spielberg",
+  "version": "0.0.3",
+  "description": "End-to-end video production pipeline with design thinking. A 6-phase orchestrator (Discovery → Storytelling → Capture → Design → Production → Audio & Render) that turns your app into a polished promo, showcase, or tutorial video, rendered with HyperFrames (HTML + GSAP).",
+  "author": {
+    "name": "Nebrass Lamouchi",
+    "email": "lnibrass@gmail.com",
+    "url": "https://github.com/nebrass"
+  },
+  "homepage": "https://github.com/nebrass/hve-spielberg",
+  "repository": "https://github.com/nebrass/hve-spielberg",
+  "license": "MIT",
+  "keywords": [
+    "video",
+    "promo",
+    "showcase",
+    "tutorial",
+    "hyperframes",
+    "gsap",
+    "elevenlabs",
+    "tts",
+    "storyboard",
+    "design-thinking",
+    "claude-code",
+    "github-copilot"
+  ],
+  "skills": "./",
+  "interface": {
+    "displayName": "hve-spielberg",
+    "shortDescription": "Turn your app into a promo, showcase, or tutorial video",
+    "longDescription": "Drive end-to-end video production with hve-spielberg: design-thinking discovery, narrative storyboarding, Chrome DevTools capture, HyperFrames (HTML + GSAP) scene design and composition, then ElevenLabs voiceover, Whisper timing verification, and Freesound music mixed and rendered to MP4. Three content modes — promo (marketing), showcase (portfolio/demo), or tutorial (walkthrough/how-to).",
+    "developerName": "Nebrass Lamouchi",
+    "category": "Design",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/nebrass/hve-spielberg",
+    "defaultPrompt": [
+      "Create a 60-second promo video for my app",
+      "Make a showcase video from my screenshots",
+      "Build a tutorial walkthrough video"
+    ],
+    "brandColor": "#0a0a0a"
+  }
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://cursor.com/schemas/cursor-plugin/plugin.json",
+  "name": "hve-spielberg",
+  "displayName": "hve-spielberg",
+  "version": "0.0.3",
+  "description": "End-to-end video production pipeline with design thinking. A 6-phase orchestrator (Discovery → Storytelling → Capture → Design → Production → Audio & Render) that turns your app into a polished promo, showcase, or tutorial video, rendered with HyperFrames (HTML + GSAP).",
+  "author": {
+    "name": "Nebrass Lamouchi",
+    "email": "lnibrass@gmail.com"
+  },
+  "homepage": "https://github.com/nebrass/hve-spielberg",
+  "repository": "https://github.com/nebrass/hve-spielberg",
+  "license": "MIT",
+  "category": "developer-tools",
+  "keywords": [
+    "video",
+    "promo",
+    "showcase",
+    "tutorial",
+    "hyperframes",
+    "gsap",
+    "elevenlabs",
+    "tts",
+    "storyboard",
+    "design-thinking",
+    "claude-code",
+    "github-copilot"
+  ],
+  "tags": [
+    "video",
+    "animation",
+    "design",
+    "creative",
+    "workflow"
+  ],
+  "skills": "./"
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## What this repo is
 
-This repo **is a Claude Code skill** (`hve-spielberg`), not a typical application. The "source" is prompt content (markdown) plus two Python helper scripts. There is no build system, no test suite, no lint config — the skill is consumed by future Claude Code sessions that invoke `/hve-spielberg <project-dir>`.
+This repo **is an agent skill** (`hve-spielberg`) that runs on both **GitHub Copilot CLI** and **Claude Code**, not a typical application. The "source" is prompt content (markdown) plus two Python helper scripts. There is no build system, no test suite, no lint config — the skill is consumed by future agent sessions that invoke `/hve-spielberg <project-dir>` (a slash command on Claude Code; invoked by name/intent on Copilot CLI). The `SKILL.md` frontmatter follows the Claude Code skill schema; Copilot CLI loads the skill from its `name`/`description` and harmlessly ignores the Claude-only fields (`allowed-tools`, `user-invocable`, `argument-hint`). See the **Runtime Compatibility** section in `SKILL.md` for how interaction blocks (`{"questions": […]}`), companion-skill loading (`Skill(<name>)`), and skill-home paths map across runtimes — preserve that mapping when editing.
 
 The renderer is **HyperFrames** (HTML + GSAP, rendered via headless Chromium). React/Remotion are **not** used.
 
@@ -38,7 +38,7 @@ SKILL.md (orchestrator)
 **External dependencies the skill calls out to:**
 
 - `mcp__chrome-devtools__*` for app capture (Phase 2)
-- The `hyperframes` Claude Code skill for HTML/GSAP authoring rules (Phases 3 + 4) — distinct from the `hyperframes` npm CLI
+- The `hyperframes` companion agent skill for HTML/GSAP authoring rules (Phases 3 + 4) — distinct from the `hyperframes` npm CLI
 - The `gsap` skill (optional companion) for choreography reference
 - `npx hyperframes` CLI for `init`, `add` (pull catalog blocks, Phase 4), `lint`, `preview`, `inspect`, `validate`, `render`, `doctor` (render-environment diagnostics, Phase 5), `transcribe` (preferred voiceover-timing verifier in Phase 5; falls back to standalone Whisper if unavailable), and `tts` (used in Phase 5 as the no-API-key fallback when `ELEVENLABS_API_KEY` is unset)
 - `mcp__chrome-devtools__screencast_*` + `resize_page` for Phase-2 web-clip capture (experimental, feature-detected — needs `--experimentalScreencast=true`; falls back to screenshots), and optional `asciinema`+`agg` for CLI clip recording (otherwise the authored-terminal path)
@@ -92,13 +92,21 @@ Anti-slop content rules (see `patterns/anti-slop.md`) also matter: no default Ta
 
 ```bash
 npx skills add nebrass/hve-spielberg                      # via Skills CLI
+
+# Claude Code
 git clone https://github.com/nebrass/hve-spielberg.git \
   ~/.claude/skills/hve-spielberg                          # manual
 cp -r ~/.claude/skills/hve-spielberg \
   my-project/.claude/skills/hve-spielberg                 # per-project copy
+
+# GitHub Copilot CLI
+git clone https://github.com/nebrass/hve-spielberg.git \
+  ~/.copilot/skills/hve-spielberg                         # manual
+cp -r ~/.copilot/skills/hve-spielberg \
+  my-project/.copilot/skills/hve-spielberg                # per-project copy
 ```
 
-When testing skill changes locally, the global install path is `~/.claude/skills/hve-spielberg/`.
+When testing skill changes locally, the global install path is `~/.claude/skills/hve-spielberg/` (Claude Code) or `~/.copilot/skills/hve-spielberg/` (GitHub Copilot CLI).
 
 ## Git / release conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,7 +103,7 @@ cp -r ~/.claude/skills/hve-spielberg \
 git clone https://github.com/nebrass/hve-spielberg.git \
   ~/.copilot/skills/hve-spielberg                         # manual
 cp -r ~/.copilot/skills/hve-spielberg \
-  my-project/.copilot/skills/hve-spielberg                # per-project copy
+  my-project/.github/skills/hve-spielberg                 # per-project copy (project .copilot/skills is not scanned)
 ```
 
 When testing skill changes locally, the global install path is `~/.claude/skills/hve-spielberg/` (Claude Code) or `~/.copilot/skills/hve-spielberg/` (GitHub Copilot CLI).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,20 +91,16 @@ Anti-slop content rules (see `patterns/anti-slop.md`) also matter: no default Ta
 ## Installation paths users invoke
 
 ```bash
-npx skills add nebrass/hve-spielberg                      # via Skills CLI
+# Recommended — the skills CLI auto-detects the agent and resolves its scanned skills home:
+npx skills add nebrass/hve-spielberg                                   # project install (Copilot scans .github/skills, .agents/skills)
+npx skills add nebrass/hve-spielberg --agent github-copilot --global  # global for Copilot CLI (~/.copilot/skills/)
+npx skills add nebrass/hve-spielberg --global                         # global for Claude Code (default agent)
 
-# Claude Code
-git clone https://github.com/nebrass/hve-spielberg.git \
-  ~/.claude/skills/hve-spielberg                          # manual
-cp -r ~/.claude/skills/hve-spielberg \
-  my-project/.claude/skills/hve-spielberg                 # per-project copy
-
-# GitHub Copilot CLI
-git clone https://github.com/nebrass/hve-spielberg.git \
-  ~/.copilot/skills/hve-spielberg                         # manual
-cp -r ~/.copilot/skills/hve-spielberg \
-  my-project/.github/skills/hve-spielberg                 # per-project copy (project .copilot/skills is not scanned)
+# Fallback — manual git clone into the agent's skills home:
+git clone https://github.com/nebrass/hve-spielberg.git ~/.copilot/skills/hve-spielberg
 ```
+
+The repo also ships per-agent plugin manifests at root (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`) plus a root `AGENTS.md`; each points its skills source at the repo root (`./`) because `SKILL.md` lives at the root, not under `skills/`.
 
 When testing skill changes locally, the global install path is `~/.claude/skills/hve-spielberg/` (Claude Code) or `~/.copilot/skills/hve-spielberg/` (GitHub Copilot CLI).
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ __pycache__/
 .vscode/
 .idea/
 
-# Claude Code session state (local runtime, not source)
+# Agent session state (local runtime, not source)
 .omo/
 
 # Throwaway render/verify harness — never committed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Skills
+
+This repo ships the **hve-spielberg** agent skill via [vercel-labs/skills](https://github.com/vercel-labs/skills). `SKILL.md` lives at the repository **root** (a single-skill layout), so the skills CLI discovers it directly — there is no `skills/` wrapper.
+
+## Install
+
+```bash
+# Project install — auto-detects your agent and writes to its project skills home
+npx skills add nebrass/hve-spielberg
+
+# Global install (Claude Code is the default agent)
+npx skills add nebrass/hve-spielberg --global
+
+# Global install for GitHub Copilot CLI (~/.copilot/skills/)
+npx skills add nebrass/hve-spielberg --agent github-copilot --global
+```
+
+The CLI auto-detects which coding agents you have installed and resolves the correct scanned skills home for each — you never hand-pick a path.
+
+## Native plugin manifests
+
+For agents that load native plugins, per-agent manifests are provided at the repo root. Each points its skills source at `./` (the repo root holds `SKILL.md`), not `./skills/`:
+
+- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — Claude Code
+- `.codex-plugin/plugin.json` — Codex
+- `.cursor-plugin/plugin.json` — Cursor
+
+All manifests are MIT-licensed, matching this repository.
+
+## Using the skill
+
+Once installed, start it with `/hve-spielberg` (a slash command on Claude Code; invoke by name or intent on GitHub Copilot CLI — run `/skills` there to confirm it loaded). It runs a 6-phase video production pipeline — see [`SKILL.md`](SKILL.md) and [`README.md`](README.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub Copilot CLI support — the skill is now agent-agnostic.** `hve-spielberg`
+  runs on both **Claude Code** (`~/.claude/skills/`) and **GitHub Copilot CLI**
+  (`~/.copilot/skills/`). A new **Runtime Compatibility** section in `SKILL.md`
+  documents the runtime-neutral conventions used throughout the workflows:
+  - `{"questions": […]}` interaction blocks are a neutral schema rendered as a native
+    multiple-choice prompt per runtime (`AskUserQuestion` on Claude Code, `ask_user`
+    on Copilot CLI).
+  - `Skill(<name>)` means "load that companion skill the way your runtime does it".
+  - Companion skills (`hyperframes`, `gsap`) and helper scripts are resolved from
+    **both** `~/.claude/skills/` and `~/.copilot/skills/`.
+  - The `SKILL.md` frontmatter keeps the Claude Code skill schema; Copilot CLI loads
+    the skill from `name`/`description` and harmlessly ignores the Claude-only fields.
+  - Prerequisite probes, the Phase 3/5 `SKILL_DIR` resolution, and the `patterns/`
+    references now detect either skills home.
+  - `README.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` document
+    installation and usage for both agents.
+
 ### Changed
 
 - **Phase 5 music mix now sits the soundtrack under the voice as a ducked bed.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     references now detect either skills home.
   - `README.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` document
     installation and usage for both agents.
+- **Per-agent plugin manifests + skills-CLI-first install docs.** Added root-level
+  `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`,
+  `.codex-plugin/plugin.json`, and `.cursor-plugin/plugin.json` (all MIT; each manifest's
+  skills source points at the repo root `./` because `SKILL.md` lives at the root, not
+  under `skills/`), plus a root `AGENTS.md` pointer. `README.md`, `CLAUDE.md`, and
+  `.github/copilot-instructions.md` now lead with
+  `npx skills add nebrass/hve-spielberg [--agent github-copilot] [--global]` and collapse
+  the hand-paired `~/.claude` / `~/.copilot` git-clone and `cp -r` install blocks into a
+  single CLI path with one manual git-clone fallback — the CLI auto-detects the agent and
+  resolves its scanned skills home.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,11 @@ These are enforced verbally in the `## DON'Ts` section of `SKILL.md`. If you mod
 - **Add a voice** → update both the `## ElevenLabs Voice IDs` table in `SKILL.md` and the `## Voices` table in `README.md` (the two tables must stay in sync).
 - **Change phase logic** → edit the relevant `workflows/phase-N-*.md`; update the prerequisite list in `SKILL.md` if a new required file is introduced.
 - **Adjust prerequisite checks** → the `## Prerequisites` block in `SKILL.md` (runs at skill entry).
+- **Add a user-interaction prompt in a workflow** → write it as a neutral `{"questions":[...]}` block (the runtime-agnostic schema), introduced by plain prose ("ask the user…", "present selectable options…"). **Never name a picker tool** (`AskUserQuestion`, `ask_user`) or write a literal tool call inside a workflow — the per-runtime binding for the question schema, `Skill(<name>)`, and `multiSelect` lives in **one place**: `SKILL.md` § Runtime Compatibility. This is the "name actions, not tools" rule that keeps the phase content portable; a tool name hard-coded in a phase body is a portability regression. (Qualified MCP names like `mcp__chrome-devtools__*` are *not* a violation — they're identical across runtimes; the rule targets names that *differ* per runtime.)
+- **Change where the skill can be installed** (`$SKILL_HOMES`) → `SKILL.md` § Runtime Compatibility holds the canonical search list. The same `SKILL_HOMES="…"` line is repeated in the `SKILL.md` prereq probe and in the `SKILL_DIR` resolver of `workflows/phase-3-design.md` + `workflows/phase-5-audio.md` (shell state can't cross the agent's separate bash calls, so the list is re-stated at each bootstrap point rather than sourced). Keep all four byte-identical; verify with:
+  ```bash
+  grep -rho 'SKILL_HOMES="[^"]*"' SKILL.md workflows/phase-3-design.md workflows/phase-5-audio.md | sort -u | wc -l   # must print 1
+  ```
 - **Bump skill metadata** → frontmatter at top of `SKILL.md` (especially `allowed-tools` if a new MCP tool is needed).
 - **Bump the GSAP version** → the CDN `<script>` tags carry a Subresource Integrity hash (`integrity="sha384-…" crossorigin="anonymous"`), pinned to `gsap@3.14.2`. Changing the version *requires* recomputing the hash, or the script is blocked and every scene renders without animation (caught by `npx hyperframes validate` in Phase 4/5). Update **all** occurrences together — `templates/scene-*.html`, the skeletons in `workflows/phase-3-design.md` + `workflows/phase-4-production.md`, and every `example/**/*.html`:
   ```bash
@@ -102,7 +107,7 @@ cp -r ~/.claude/skills/hve-spielberg \
 git clone https://github.com/nebrass/hve-spielberg.git \
   ~/.copilot/skills/hve-spielberg                         # manual
 cp -r ~/.copilot/skills/hve-spielberg \
-  my-project/.copilot/skills/hve-spielberg                # per-project copy
+  my-project/.github/skills/hve-spielberg                 # per-project copy (project .copilot/skills is not scanned)
 ```
 
 When testing skill changes locally, the global install path is `~/.claude/skills/hve-spielberg/` (Claude Code) or `~/.copilot/skills/hve-spielberg/` (GitHub Copilot CLI).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,20 +95,16 @@ These are enforced verbally in the `## DON'Ts` section of `SKILL.md`. If you mod
 ## Installation paths users invoke
 
 ```bash
-npx skills add nebrass/hve-spielberg                      # via Skills CLI
+# Recommended — the skills CLI auto-detects the agent and resolves its skills home:
+npx skills add nebrass/hve-spielberg                                   # project install
+npx skills add nebrass/hve-spielberg --global                         # global (Claude Code default)
+npx skills add nebrass/hve-spielberg --agent github-copilot --global  # global for Copilot CLI
 
-# Claude Code
-git clone https://github.com/nebrass/hve-spielberg.git \
-  ~/.claude/skills/hve-spielberg                          # manual
-cp -r ~/.claude/skills/hve-spielberg \
-  my-project/.claude/skills/hve-spielberg                 # per-project copy
-
-# GitHub Copilot CLI
-git clone https://github.com/nebrass/hve-spielberg.git \
-  ~/.copilot/skills/hve-spielberg                         # manual
-cp -r ~/.copilot/skills/hve-spielberg \
-  my-project/.github/skills/hve-spielberg                 # per-project copy (project .copilot/skills is not scanned)
+# Fallback — manual git clone into the agent's skills home:
+git clone https://github.com/nebrass/hve-spielberg.git ~/.claude/skills/hve-spielberg
 ```
+
+The repo also ships per-agent plugin manifests at root (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`) plus a root `AGENTS.md`; each points its skills source at the repo root (`./`) because `SKILL.md` lives at the root, not under `skills/`.
 
 When testing skill changes locally, the global install path is `~/.claude/skills/hve-spielberg/` (Claude Code) or `~/.copilot/skills/hve-spielberg/` (GitHub Copilot CLI).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) — and GitHub Copilot CLI, which also reads `CLAUDE.md` — when working with code in this repository.
 
 ## What this repo is
 
-This repo **is a Claude Code skill** (`hve-spielberg`), not a typical application. The "source" is prompt content (markdown) plus two Python helper scripts. There is no build system, no test suite, no lint config — the skill is consumed by future Claude Code sessions that invoke `/hve-spielberg <project-dir>`.
+This repo **is an agent skill** (`hve-spielberg`) that runs on both **Claude Code** and **GitHub Copilot CLI**, not a typical application. The "source" is prompt content (markdown) plus two Python helper scripts. There is no build system, no test suite, no lint config — the skill is consumed by future agent sessions that invoke `/hve-spielberg <project-dir>` (a slash command on Claude Code; invoked by name/intent on Copilot CLI). The `SKILL.md` frontmatter uses the Claude Code skill schema; Copilot CLI loads the skill from `name`/`description` and harmlessly ignores the Claude-only fields.
 
 The renderer is **HyperFrames** (HTML + GSAP, rendered via headless Chromium). React/Remotion are no longer used.
 
@@ -91,13 +91,21 @@ These are enforced verbally in the `## DON'Ts` section of `SKILL.md`. If you mod
 
 ```bash
 npx skills add nebrass/hve-spielberg                      # via Skills CLI
+
+# Claude Code
 git clone https://github.com/nebrass/hve-spielberg.git \
   ~/.claude/skills/hve-spielberg                          # manual
 cp -r ~/.claude/skills/hve-spielberg \
   my-project/.claude/skills/hve-spielberg                 # per-project copy
+
+# GitHub Copilot CLI
+git clone https://github.com/nebrass/hve-spielberg.git \
+  ~/.copilot/skills/hve-spielberg                         # manual
+cp -r ~/.copilot/skills/hve-spielberg \
+  my-project/.copilot/skills/hve-spielberg                # per-project copy
 ```
 
-When testing skill changes locally, the global install path is `~/.claude/skills/hve-spielberg/`.
+When testing skill changes locally, the global install path is `~/.claude/skills/hve-spielberg/` (Claude Code) or `~/.copilot/skills/hve-spielberg/` (GitHub Copilot CLI).
 
 ## Git / release conventions
 

--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ In Copilot CLI, run `/skills` to confirm the skill is loaded.
 
 ### Option 3: Git Submodule / Direct Copy
 
-Copy the skill files directly into any project's skills directory (`.claude/skills/` for Claude Code, `.copilot/skills/` for Copilot CLI):
+Copy the skill files directly into any project's skills directory (`.claude/skills/` for Claude Code; `.github/skills/` for Copilot CLI — its project-level `.copilot/skills/` is **not** scanned):
 
 ```bash
 # Claude Code
 cp -r ~/.claude/skills/hve-spielberg my-project/.claude/skills/hve-spielberg
 
 # GitHub Copilot CLI
-cp -r ~/.copilot/skills/hve-spielberg my-project/.copilot/skills/hve-spielberg
+cp -r ~/.copilot/skills/hve-spielberg my-project/.github/skills/hve-spielberg
 ```
 
 ## Updating

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hve-spielberg
 
-**AI-powered video production pipeline for Claude Code.** From design thinking to final render — 6 automated phases that turn your app into a polished promo, showcase, or tutorial video.
+**AI-powered video production pipeline for Claude Code and GitHub Copilot CLI.** From design thinking to final render — 6 automated phases that turn your app into a polished promo, showcase, or tutorial video.
 
 ```
 /hve-spielberg
@@ -24,7 +24,7 @@ Everything in [`example/`](example/) is the actual artifact — not a staged moc
 
 ## What It Does
 
-hve-spielberg is a Claude Code skill that orchestrates end-to-end video production:
+hve-spielberg is an agent skill (Claude Code / GitHub Copilot CLI) that orchestrates end-to-end video production:
 
 1. **Understands your product** through design thinking (empathize, define, ideate)
 2. **Builds a narrative** with scene storyboarding and emotional arc
@@ -67,7 +67,7 @@ Each phase has a user-approval checkpoint before proceeding to the next.
 | Python 3.10+ | Yes | [python.org](https://python.org) |
 | ffmpeg | Yes | `brew install ffmpeg` / `apt install ffmpeg` |
 | `chrome-headless-shell` | Yes | Used by `npx hyperframes render` for frame capture. System Chrome causes 120s render hangs. Install once: `npx puppeteer browsers install chrome-headless-shell` (one-time, ~170MB, cached). Verify with `npx hyperframes doctor`. |
-| Chrome DevTools MCP | Yes | Configured in Claude Code settings |
+| Chrome DevTools MCP | Yes | Configured in your agent's MCP settings (Claude Code or GitHub Copilot CLI) |
 | `ELEVENLABS_API_KEY` | Recommended | [elevenlabs.io](https://elevenlabs.io) — higher-quality TTS. If unset, Phase 5 falls back to `npx hyperframes tts` (local Kokoro-82M, no key, lower quality). |
 | `FREESOUND_API_KEY` | No | [freesound.org/apiv2/apply](https://freesound.org/apiv2/apply/) — enables CC music search |
 | Whisper | Recommended | `pip install openai-whisper` — voiceover timing verification |
@@ -77,15 +77,17 @@ Each phase has a user-approval checkpoint before proceeding to the next.
 
 ### Required Skills
 
-hve-spielberg depends on two **Claude Code skills** plus the **`hyperframes` npm package** (these are separate — the skills provide authoring prompts; the npm package provides the `hyperframes` CLI):
+hve-spielberg depends on two **companion agent skills** plus the **`hyperframes` npm package** (these are separate — the skills provide authoring prompts; the npm package provides the `hyperframes` CLI). Install the companion skills into the same skills home as this skill — `~/.claude/skills/` for Claude Code or `~/.copilot/skills/` for GitHub Copilot CLI:
 
 | Dependency | Type | Purpose | Install |
 |-----------|------|---------|---------|
-| `hyperframes` skill | Claude Code skill | Authoring rules for HTML/GSAP compositions, sub-comps, transitions, captions | Install the HyperFrames skill into `~/.claude/skills/hyperframes/` |
-| `gsap` skill | Claude Code skill | Animation choreography reference (eases, timelines, stagger) | Recommended companion to the hyperframes skill |
+| `hyperframes` skill | Agent skill | Authoring rules for HTML/GSAP compositions, sub-comps, transitions, captions | Install the HyperFrames skill into `~/.claude/skills/hyperframes/` (Claude Code) or `~/.copilot/skills/hyperframes/` (Copilot CLI) |
+| `gsap` skill | Agent skill | Animation choreography reference (eases, timelines, stagger) | Recommended companion to the hyperframes skill |
 | `hyperframes` npm package | CLI | `init`, `add` (pull catalog blocks, Phase 4), `lint`, `preview`, `inspect`, `validate`, `render`, `doctor` (render diagnostics), `transcribe` (Phase 5's preferred timing verifier, with standalone Whisper as fallback), `tts` (no-key fallback when `ELEVENLABS_API_KEY` is unset) | `npx hyperframes <command>` (auto-fetches; package: [`hyperframes`](https://www.npmjs.com/package/hyperframes), repo: [github.com/heygen-com/hyperframes](https://github.com/heygen-com/hyperframes)) |
 
 ## Installation
+
+The skill works with both **Claude Code** (`~/.claude/skills/`) and **GitHub Copilot CLI** (`~/.copilot/skills/`). Pick the skills home for your agent.
 
 ### Option 1: Skills CLI (Recommended)
 
@@ -93,18 +95,28 @@ hve-spielberg depends on two **Claude Code skills** plus the **`hyperframes` npm
 npx skills add nebrass/hve-spielberg
 ```
 
-### Option 2: Manual
+### Option 2: Manual (git clone)
 
 ```bash
+# Claude Code
 git clone https://github.com/nebrass/hve-spielberg.git ~/.claude/skills/hve-spielberg
+
+# GitHub Copilot CLI
+git clone https://github.com/nebrass/hve-spielberg.git ~/.copilot/skills/hve-spielberg
 ```
+
+In Copilot CLI, run `/skills` to confirm the skill is loaded.
 
 ### Option 3: Git Submodule / Direct Copy
 
-Copy the skill files directly into any project's `.claude/skills/` directory:
+Copy the skill files directly into any project's skills directory (`.claude/skills/` for Claude Code, `.copilot/skills/` for Copilot CLI):
 
 ```bash
+# Claude Code
 cp -r ~/.claude/skills/hve-spielberg my-project/.claude/skills/hve-spielberg
+
+# GitHub Copilot CLI
+cp -r ~/.copilot/skills/hve-spielberg my-project/.copilot/skills/hve-spielberg
 ```
 
 ## Updating
@@ -115,11 +127,12 @@ Already installed an older version? Update to the latest `main`:
 # Installed via the Skills CLI (npx skills add …):
 npx skills update hve-spielberg     # alias: upgrade · -g global · -p project · -y skip the scope prompt
 
-# Installed via a manual git clone (~/.claude/skills/hve-spielberg):
-cd ~/.claude/skills/hve-spielberg && git pull
+# Installed via a manual git clone:
+cd ~/.claude/skills/hve-spielberg && git pull     # Claude Code
+cd ~/.copilot/skills/hve-spielberg && git pull    # GitHub Copilot CLI
 ```
 
-Then **restart Claude Code** so the updated `SKILL.md` reloads — skills are read at session start, so file changes don't apply mid-session. Run `npx skills list` to see what's installed and where.
+Then **restart your agent** (Claude Code or GitHub Copilot CLI) so the updated `SKILL.md` reloads — skills are read at session start, so file changes don't apply mid-session. Run `npx skills list` to see what's installed and where.
 
 ## Quick Start
 
@@ -133,6 +146,7 @@ Then **restart Claude Code** so the updated `SKILL.md` reloads — skills are re
    ```
    /hve-spielberg
    ```
+   On **Claude Code** this is a slash command. On **GitHub Copilot CLI**, invoke it by name or intent (e.g. "use hve-spielberg to make a promo video"); run `/skills` to confirm it's loaded. Append the same arguments either way (e.g. `--mode continue`).
 
 3. **Follow the prompts.** Phase 0 → 5 is interactive; each phase has a user-approval checkpoint before advancing. The discovery questions include:
    - **Mode**: Promo, Showcase, or Tutorial
@@ -207,7 +221,7 @@ my-video-project/
 ```
 hve-spielberg/
 ├── SKILL.md                       # Orchestrator entry point (read first)
-├── CLAUDE.md                      # Codebase guide for Claude Code sessions editing this repo
+├── CLAUDE.md                      # Codebase guide for agent sessions (Claude Code / Copilot CLI) editing this repo
 ├── workflows/                     # The 6-phase pipeline, one file per phase
 │   ├── phase-0-discovery.md
 │   ├── phase-1-storytelling.md

--- a/README.md
+++ b/README.md
@@ -77,46 +77,40 @@ Each phase has a user-approval checkpoint before proceeding to the next.
 
 ### Required Skills
 
-hve-spielberg depends on two **companion agent skills** plus the **`hyperframes` npm package** (these are separate — the skills provide authoring prompts; the npm package provides the `hyperframes` CLI). Install the companion skills into the same skills home as this skill — `~/.claude/skills/` for Claude Code or `~/.copilot/skills/` for GitHub Copilot CLI:
+hve-spielberg depends on two **companion agent skills** plus the **`hyperframes` npm package** (these are separate — the skills provide authoring prompts; the npm package provides the `hyperframes` CLI). Install the companion skills the same way as this skill — with `npx skills add` (see [Installation](#installation)), which auto-detects your agent and resolves the correct skills home for you:
 
 | Dependency | Type | Purpose | Install |
 |-----------|------|---------|---------|
-| `hyperframes` skill | Agent skill | Authoring rules for HTML/GSAP compositions, sub-comps, transitions, captions | Install the HyperFrames skill into `~/.claude/skills/hyperframes/` (Claude Code) or `~/.copilot/skills/hyperframes/` (Copilot CLI) |
+| `hyperframes` skill | Agent skill | Authoring rules for HTML/GSAP compositions, sub-comps, transitions, captions | `npx skills add heygen-com/hyperframes` |
 | `gsap` skill | Agent skill | Animation choreography reference (eases, timelines, stagger) | Recommended companion to the hyperframes skill |
 | `hyperframes` npm package | CLI | `init`, `add` (pull catalog blocks, Phase 4), `lint`, `preview`, `inspect`, `validate`, `render`, `doctor` (render diagnostics), `transcribe` (Phase 5's preferred timing verifier, with standalone Whisper as fallback), `tts` (no-key fallback when `ELEVENLABS_API_KEY` is unset) | `npx hyperframes <command>` (auto-fetches; package: [`hyperframes`](https://www.npmjs.com/package/hyperframes), repo: [github.com/heygen-com/hyperframes](https://github.com/heygen-com/hyperframes)) |
 
 ## Installation
 
-The skill works with both **Claude Code** (`~/.claude/skills/`) and **GitHub Copilot CLI** (`~/.copilot/skills/`). Pick the skills home for your agent.
+The recommended install is the **[skills CLI](https://github.com/vercel-labs/skills)** — it auto-detects your agent (Claude Code, GitHub Copilot CLI) and installs into the skills home that agent actually scans, so you never hand-pick a path. It also installs the per-agent plugin manifests this repo ships (`.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`).
 
-### Option 1: Skills CLI (Recommended)
+### Recommended: Skills CLI
 
 ```bash
+# Project install — run from your project; writes to the agent's project skills home
 npx skills add nebrass/hve-spielberg
-```
 
-### Option 2: Manual (git clone)
+# Global install (Claude Code is the default agent)
+npx skills add nebrass/hve-spielberg --global
 
-```bash
-# Claude Code
-git clone https://github.com/nebrass/hve-spielberg.git ~/.claude/skills/hve-spielberg
-
-# GitHub Copilot CLI
-git clone https://github.com/nebrass/hve-spielberg.git ~/.copilot/skills/hve-spielberg
+# Global install for GitHub Copilot CLI (~/.copilot/skills/)
+npx skills add nebrass/hve-spielberg --agent github-copilot --global
 ```
 
 In Copilot CLI, run `/skills` to confirm the skill is loaded.
 
-### Option 3: Git Submodule / Direct Copy
+### Fallback: manual git clone
 
-Copy the skill files directly into any project's skills directory (`.claude/skills/` for Claude Code; `.github/skills/` for Copilot CLI — its project-level `.copilot/skills/` is **not** scanned):
+If you can't run the CLI, clone the repo into your agent's skills home directly:
 
 ```bash
-# Claude Code
-cp -r ~/.claude/skills/hve-spielberg my-project/.claude/skills/hve-spielberg
-
-# GitHub Copilot CLI
-cp -r ~/.copilot/skills/hve-spielberg my-project/.github/skills/hve-spielberg
+git clone https://github.com/nebrass/hve-spielberg.git ~/.claude/skills/hve-spielberg
+# GitHub Copilot CLI: clone into ~/.copilot/skills/hve-spielberg instead
 ```
 
 ## Updating
@@ -124,13 +118,10 @@ cp -r ~/.copilot/skills/hve-spielberg my-project/.github/skills/hve-spielberg
 Already installed an older version? Update to the latest `main`:
 
 ```bash
-# Installed via the Skills CLI (npx skills add …):
 npx skills update hve-spielberg     # alias: upgrade · -g global · -p project · -y skip the scope prompt
-
-# Installed via a manual git clone:
-cd ~/.claude/skills/hve-spielberg && git pull     # Claude Code
-cd ~/.copilot/skills/hve-spielberg && git pull    # GitHub Copilot CLI
 ```
+
+Installed via a manual git clone instead? `cd` into the skills home you cloned to and run `git pull`.
 
 Then **restart your agent** (Claude Code or GitHub Copilot CLI) so the updated `SKILL.md` reloads — skills are read at session start, so file changes don't apply mid-session. Run `npx skills list` to see what's installed and where.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,6 +22,27 @@ You also understand **design thinking** — you don't just make videos, you firs
 
 Your creative instincts guide every decision. The guidelines below are suggestions, not rules.
 
+## Runtime Compatibility
+
+This skill is **agent-agnostic** — it runs on both **Claude Code** and **GitHub Copilot CLI**.
+A few conventions in this file and the phase workflows are written once and mapped to whatever
+runtime you are on:
+
+- **Frontmatter** (`allowed-tools`, `user-invocable`, `argument-hint`) follows the Claude Code
+  skill schema. GitHub Copilot CLI loads this skill from the `name`/`description` fields and
+  harmlessly ignores the rest — there is nothing to change.
+- **Asking the user a question.** Wherever a `{"questions": [...]}` JSON block appears, treat it
+  as a runtime-neutral schema: render each question as a **native multiple-choice prompt** using
+  whatever selection tool your runtime provides — `AskUserQuestion` on Claude Code, `ask_user` on
+  GitHub Copilot CLI. `multiSelect: true` means allow multiple selections. Never print the raw
+  JSON to the user.
+- **Loading a companion skill.** Wherever you see `Skill(<name>)` (e.g. `Skill(hyperframes)`),
+  load that skill the way your runtime does it — the `Skill` tool on Claude Code, or read the
+  companion skill's `SKILL.md` (auto-discovered alongside this one) on GitHub Copilot CLI.
+- **Skill install home.** Companion skills (`hyperframes`, `gsap`) live next to this skill:
+  `~/.claude/skills/<name>/` on Claude Code, `~/.copilot/skills/<name>/` on GitHub Copilot CLI.
+  Prereq checks below probe **both** locations.
+
 ## Prerequisites
 
 Check required tools and skills:
@@ -37,8 +58,12 @@ echo "asciinema+agg+timeout (CLI clip recording): optional — $(command -v asci
 ```
 
 ```bash
-ls ~/.claude/skills/hyperframes/SKILL.md 2>/dev/null && echo "hyperframes skill: ✓" || echo "hyperframes skill: ✗ — install the Claude Code skill (authoring prompts)"
-ls ~/.claude/skills/gsap/SKILL.md 2>/dev/null && echo "gsap skill: ✓"        || echo "gsap skill: ○ — recommended companion to hyperframes for animation choreography"
+for home in ~/.claude/skills ~/.copilot/skills; do
+  [ -f "$home/hyperframes/SKILL.md" ] && { echo "hyperframes skill: ✓ ($home)"; hf=1; break; }
+done; [ -n "$hf" ] || echo "hyperframes skill: ✗ — install the hyperframes skill into ~/.claude/skills/ (Claude Code) or ~/.copilot/skills/ (GitHub Copilot CLI)"
+for home in ~/.claude/skills ~/.copilot/skills; do
+  [ -f "$home/gsap/SKILL.md" ] && { echo "gsap skill: ✓ ($home)"; gs=1; break; }
+done; [ -n "$gs" ] || echo "gsap skill: ○ — recommended companion to hyperframes for animation choreography"
 npx --yes hyperframes --version 2>/dev/null && echo "hyperframes CLI: ✓" || echo "hyperframes CLI: ✗ — npm i -g hyperframes  (or rely on npx; package: hyperframes on npm, repo github.com/heygen-com/hyperframes)"
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -34,14 +34,28 @@ runtime you are on:
 - **Asking the user a question.** Wherever a `{"questions": [...]}` JSON block appears, treat it
   as a runtime-neutral schema: render each question as a **native multiple-choice prompt** using
   whatever selection tool your runtime provides — `AskUserQuestion` on Claude Code, `ask_user` on
-  GitHub Copilot CLI. `multiSelect: true` means allow multiple selections. Never print the raw
-  JSON to the user.
+  GitHub Copilot CLI. Never print the raw JSON to the user. `multiSelect: true` means the user may
+  pick several options — on a runtime whose picker is single-select only (Copilot CLI's `ask_user`),
+  do **not** silently keep one answer: ask the question as a free-text prompt that invites a
+  comma-separated list, or repeat the single-select until the user signals "done," so every chosen
+  option survives into `context.md`.
 - **Loading a companion skill.** Wherever you see `Skill(<name>)` (e.g. `Skill(hyperframes)`),
   load that skill the way your runtime does it — the `Skill` tool on Claude Code, or read the
   companion skill's `SKILL.md` (auto-discovered alongside this one) on GitHub Copilot CLI.
-- **Skill install home.** Companion skills (`hyperframes`, `gsap`) live next to this skill:
-  `~/.claude/skills/<name>/` on Claude Code, `~/.copilot/skills/<name>/` on GitHub Copilot CLI.
-  Prereq checks below probe **both** locations.
+- **Skill install home.** Companion skills (`hyperframes`, `gsap`) live next to this skill in
+  whichever home your runtime scans — `~/.claude/skills/<name>/` (Claude Code) or
+  `~/.copilot/skills/<name>/` (Copilot CLI) for a global install, or the project-level home
+  (`.claude/skills/` on Claude Code; `.github/skills/` or `.agents/skills/` on Copilot CLI — note
+  project-level `.copilot/skills/` is **not** scanned).
+
+  These homes, in this order, are the **single canonical list** — the prereq probe below and every
+  workflow's `SKILL_DIR` resolver derive from exactly this `$SKILL_HOMES` definition. Change it here
+  and nowhere else:
+
+  ```bash
+  # CANONICAL skill-home search list (global first, then project; Claude Code + Copilot CLI).
+  SKILL_HOMES="$HOME/.claude/skills $HOME/.copilot/skills $HOME/.agents/skills .claude/skills .github/skills .agents/skills"
+  ```
 
 ## Prerequisites
 
@@ -58,12 +72,18 @@ echo "asciinema+agg+timeout (CLI clip recording): optional — $(command -v asci
 ```
 
 ```bash
-for home in ~/.claude/skills ~/.copilot/skills; do
-  [ -f "$home/hyperframes/SKILL.md" ] && { echo "hyperframes skill: ✓ ($home)"; hf=1; break; }
-done; [ -n "$hf" ] || echo "hyperframes skill: ✗ — install the hyperframes skill into ~/.claude/skills/ (Claude Code) or ~/.copilot/skills/ (GitHub Copilot CLI)"
-for home in ~/.claude/skills ~/.copilot/skills; do
-  [ -f "$home/gsap/SKILL.md" ] && { echo "gsap skill: ✓ ($home)"; gs=1; break; }
-done; [ -n "$gs" ] || echo "gsap skill: ○ — recommended companion to hyperframes for animation choreography"
+# Probe the canonical skill homes ($SKILL_HOMES, defined in § Runtime Compatibility above).
+SKILL_HOMES="$HOME/.claude/skills $HOME/.copilot/skills $HOME/.agents/skills .claude/skills .github/skills .agents/skills"
+for s in hyperframes gsap; do
+  found=
+  for home in $SKILL_HOMES; do
+    [ -f "$home/$s/SKILL.md" ] && { echo "$s skill: ✓ ($home)"; found=1; break; }
+  done
+  [ -n "$found" ] && continue
+  [ "$s" = hyperframes ] \
+    && echo "hyperframes skill: ✗ — install it into ~/.claude/skills/ (Claude Code) or ~/.copilot/skills/ (GitHub Copilot CLI)" \
+    || echo "gsap skill: ○ — recommended companion to hyperframes for animation choreography"
+done
 npx --yes hyperframes --version 2>/dev/null && echo "hyperframes CLI: ✓" || echo "hyperframes CLI: ✗ — npm i -g hyperframes  (or rely on npx; package: hyperframes on npm, repo github.com/heygen-com/hyperframes)"
 ```
 

--- a/design-systems/CONTRIBUTING.md
+++ b/design-systems/CONTRIBUTING.md
@@ -44,7 +44,7 @@ $EDITOR design-systems/<slug>/DESIGN.md
 # 4. Add a row to the catalog table in design-systems/README.md
 
 # 5. Add an option to Phase 1 Step 1.2 in workflows/phase-1-storytelling.md
-#    (the second AskUserQuestion block, "Which design system?")
+#    (the second question block, "Which design system?")
 
 # 6. Verify the slug appears in all three:
 #    - templates/project-plan.md `Design system:` enum

--- a/patterns/INDEX.md
+++ b/patterns/INDEX.md
@@ -13,7 +13,7 @@ Quick map: *"I need to do X"* → *"read this file."* hve-spielberg leans on the
 | `anti-slop.md` | Cardinal sins, soft tells, polish tells — distinguishes "shipped by a marketer" from "AI default output". Includes **§ AI Tool Promo Specifics** (dogfooding loop, show-don't-tell, 1-based phase numbering) and **§ CTA discipline** (full URL on screen, match canonical command). |
 | `cli-terminal-capture.md` | Professional CLI scene recording via `asciinema` + `agg`: install, shell pre-flight (prompt, secrets, size), recording flags, cast editing, theme→palette pairing, MP4 render, quality gate, troubleshooting. Read when the storyboard calls for a real terminal clip; for the no-dep fallback see `templates/scene-terminal.html`. |
 
-## HyperFrames skill references (in `~/.claude/skills/hyperframes/`)
+## HyperFrames skill references (in `~/.claude/skills/hyperframes/` or `~/.copilot/skills/hyperframes/`)
 
 The `hyperframes` skill is invoked in Phases 3 and 4. Once invoked, these files are accessible. Read by-task, not by-default — loading the whole skill at once eats context.
 

--- a/patterns/marker-highlight.md
+++ b/patterns/marker-highlight.md
@@ -258,4 +258,4 @@ tl.to("#sketchout-1 .mh-sketchout-bwd",
 
 ## Source
 
-Full versions of these patterns (including multi-line variants, mode-cycling for captions, and the path-length math) live in the HyperFrames skill at `~/.claude/skills/hyperframes/references/css-patterns.md`. This file is a product-video focused subset.
+Full versions of these patterns (including multi-line variants, mode-cycling for captions, and the path-length math) live in the HyperFrames skill at `<skills-home>/hyperframes/references/css-patterns.md` (`<skills-home>` is `~/.claude/skills` on Claude Code or `~/.copilot/skills` on GitHub Copilot CLI). This file is a product-video focused subset.

--- a/patterns/transition-catalog.md
+++ b/patterns/transition-catalog.md
@@ -49,7 +49,7 @@ See `workflows/phase-4-production.md` Step 4.2 for how to wire them into the roo
 | `references/transitions/css-grid.md` | Grid Dissolve |
 | `references/transitions/css-other.md` | Gravity Drop, Morph Circle |
 
-All paths are relative to `~/.claude/skills/hyperframes/` (the installed HF skill location).
+All paths are relative to the installed HyperFrames skill location — `~/.claude/skills/hyperframes/` (Claude Code) or `~/.copilot/skills/hyperframes/` (GitHub Copilot CLI).
 
 ## Hard rules (don't skip these)
 

--- a/workflows/phase-3-design.md
+++ b/workflows/phase-3-design.md
@@ -13,7 +13,10 @@ Pick the most specific path that Phase 1 Step 1.2 set up.
 **If Phase 1 recorded `design_system: <slug>`** in `project-plan.md` (one of `stripe`, `linear-app`, `apple`, `notion`, `vercel`, `airbnb`, `github`, `cal`, `arc`, `bento`), the brand specification ships with the skill. Copy it straight into the project root:
 
 ```bash
-SKILL_DIR=~/.claude/skills/hve-spielberg   # or .claude/skills/hve-spielberg for per-project install
+# Resolve the skill install dir across runtimes (Claude Code / GitHub Copilot CLI),
+# global or per-project:
+SKILL_DIR=$(for d in ~/.claude/skills/hve-spielberg ~/.copilot/skills/hve-spielberg \
+  .claude/skills/hve-spielberg .copilot/skills/hve-spielberg; do [ -d "$d" ] && echo "$d" && break; done)
 cp "$SKILL_DIR/design-systems/<slug>/DESIGN.md" ./DESIGN.md
 ```
 

--- a/workflows/phase-3-design.md
+++ b/workflows/phase-3-design.md
@@ -13,10 +13,11 @@ Pick the most specific path that Phase 1 Step 1.2 set up.
 **If Phase 1 recorded `design_system: <slug>`** in `project-plan.md` (one of `stripe`, `linear-app`, `apple`, `notion`, `vercel`, `airbnb`, `github`, `cal`, `arc`, `bento`), the brand specification ships with the skill. Copy it straight into the project root:
 
 ```bash
-# Resolve the skill install dir across runtimes (Claude Code / GitHub Copilot CLI),
-# global or per-project:
-SKILL_DIR=$(for d in ~/.claude/skills/hve-spielberg ~/.copilot/skills/hve-spielberg \
-  .claude/skills/hve-spielberg .copilot/skills/hve-spielberg; do [ -d "$d" ] && echo "$d" && break; done)
+# $SKILL_HOMES is the canonical home list defined in SKILL.md § Runtime Compatibility.
+# Keep this line identical to that definition; edit it there, not here.
+SKILL_HOMES="$HOME/.claude/skills $HOME/.copilot/skills $HOME/.agents/skills .claude/skills .github/skills .agents/skills"
+SKILL_DIR=$(for h in $SKILL_HOMES; do [ -d "$h/hve-spielberg" ] && echo "$h/hve-spielberg" && break; done)
+[ -n "$SKILL_DIR" ] || { echo "ERROR: hve-spielberg install dir not found — set SKILL_DIR to the skill's path manually" >&2; }
 cp "$SKILL_DIR/design-systems/<slug>/DESIGN.md" ./DESIGN.md
 ```
 

--- a/workflows/phase-5-audio.md
+++ b/workflows/phase-5-audio.md
@@ -75,10 +75,11 @@ would bake this project's config into every future project, and two projects
 could not run concurrently.
 
 ```bash
-# Resolve the skill install dir across runtimes (Claude Code / GitHub Copilot CLI),
-# global or per-project:
-SKILL_DIR=$(for d in ~/.claude/skills/hve-spielberg ~/.copilot/skills/hve-spielberg \
-  .claude/skills/hve-spielberg .copilot/skills/hve-spielberg; do [ -d "$d" ] && echo "$d" && break; done)
+# $SKILL_HOMES is the canonical home list defined in SKILL.md § Runtime Compatibility.
+# Keep this line identical to that definition; edit it there, not here.
+SKILL_HOMES="$HOME/.claude/skills $HOME/.copilot/skills $HOME/.agents/skills .claude/skills .github/skills .agents/skills"
+SKILL_DIR=$(for h in $SKILL_HOMES; do [ -d "$h/hve-spielberg" ] && echo "$h/hve-spielberg" && break; done)
+[ -n "$SKILL_DIR" ] || { echo "ERROR: hve-spielberg install dir not found — set SKILL_DIR to the skill's path manually" >&2; }
 cp "$SKILL_DIR/scripts/generate_voiceover.py" ./voiceover.py
 ```
 

--- a/workflows/phase-5-audio.md
+++ b/workflows/phase-5-audio.md
@@ -75,7 +75,10 @@ would bake this project's config into every future project, and two projects
 could not run concurrently.
 
 ```bash
-SKILL_DIR=~/.claude/skills/hve-spielberg   # or .claude/skills/hve-spielberg for per-project install
+# Resolve the skill install dir across runtimes (Claude Code / GitHub Copilot CLI),
+# global or per-project:
+SKILL_DIR=$(for d in ~/.claude/skills/hve-spielberg ~/.copilot/skills/hve-spielberg \
+  .claude/skills/hve-spielberg .copilot/skills/hve-spielberg; do [ -d "$d" ] && echo "$d" && break; done)
 cp "$SKILL_DIR/scripts/generate_voiceover.py" ./voiceover.py
 ```
 


### PR DESCRIPTION
## What & why

`hve-spielberg` is published as a Claude Code skill, but it also loads and runs under **GitHub Copilot CLI** (place it in `~/.copilot/skills/` and it's picked up from the `SKILL.md` `name`/`description`). A few Claude-specific assumptions caused friction under Copilot. This PR makes the skill **agent-agnostic** so it behaves the same on both runtimes, and documents install/usage for each.

Closes #6.

## Changes

- **`SKILL.md` — new `## Runtime Compatibility` section** that maps the runtime-neutral conventions used throughout the workflows:
  - `{"questions": […]}` interaction blocks → render as a native multiple-choice prompt (`AskUserQuestion` on Claude Code, `ask_user` on Copilot CLI).
  - `Skill(<name>)` → load the companion skill the way your runtime does it.
  - Companion skills / scripts resolve from **both** `~/.claude/skills/` and `~/.copilot/skills/`.
  - Frontmatter stays on the Claude Code skill schema; Copilot CLI ignores the Claude-only keys harmlessly (so no regression for Claude users).
- **Prereq probes** (`SKILL.md`) and the **Phase 3 / Phase 5 `SKILL_DIR`** resolution now detect either skills home.
- **`patterns/`** references (`INDEX.md`, `transition-catalog.md`, `marker-highlight.md`) point at either skills home.
- **Docs** — `README.md` adds Copilot CLI install (`~/.copilot/skills/`, `/skills`) + usage notes and generalizes the Claude-only framing; `CLAUDE.md` and `.github/copilot-instructions.md` describe both runtimes.
- **`CHANGELOG.md`** — entry under `[Unreleased]`.

## Out of scope

No changes to the rendering pipeline, HyperFrames/GSAP rules, design systems, or the `example/` reference build (its narration text intentionally says "Made in Claude Code").

## Validation

- Prereq probe finds companion skills under either home and degrades gracefully when absent (doesn't crash).
- `SKILL_DIR` resolution finds the install under `~/.copilot/skills/` as well as `~/.claude/skills/`.
- Every remaining `~/.claude/...` reference is now paired with its `~/.copilot/...` equivalent.
