### PR TITLE
fix(phase-5): mono-voiceover sidechain mix + WSL/low-memory render path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Phase 5 audio mix and render hardened from a real Copilot CLI end-to-end run.** Two
+  environment fixes verified by rendering the `example/` build to MP4:
+  - The sidechain mix now forces both legs to stereo with
+    `aformat=…:channel_layouts=stereo` (was a bare `aresample=44100`). ElevenLabs and the
+    `hyperframes tts` fallback often emit a **mono** voiceover, and `sidechaincompress` aborts
+    (`Failed to inject frame into filter network`) when the key and music differ in channel
+    layout. Updated in `workflows/phase-5-audio.md` and `example/README.md`.
+  - Documented the WSL2 render path: native render can fail at
+    `Protocol error (Page.captureScreenshot)`; add `--docker` to render in a container, and on
+    machines with ≤8 GB RAM also add `--no-low-memory-mode` (low-memory mode forces the failing
+    screenshot capture). Added to the Phase 5 "Known issues" list and the `example/README.md`
+    render step.
 - **Phase 5 music mix now sits the soundtrack under the voice as a ducked bed.**
   The static `volume=0.22` blend in `workflows/phase-5-audio.md` is replaced with:
   music normalized to a known base (`loudnorm I=-30`), EQ space carved for speech

--- a/example/README.md
+++ b/example/README.md
@@ -59,12 +59,15 @@ ffmpeg -y -i voiceover-normalized.mp3 -i background-music.mp3 \
   -filter_complex "
     [1:a]atrim=0:60,loudnorm=I=-30:TP=-3:LRA=11,
          highpass=f=100,equalizer=f=2500:t=q:w=1:g=-3,
-         afade=t=in:st=0:d=2,afade=t=out:st=56:d=4,aresample=44100[music];
-    [0:a]aresample=44100,asplit=2[vo][key];
+         afade=t=in:st=0:d=2,afade=t=out:st=56:d=4,aformat=sample_fmts=fltp:sample_rates=44100:channel_layouts=stereo[music];
+    [0:a]aformat=sample_fmts=fltp:sample_rates=44100:channel_layouts=stereo,asplit=2[vo][key];
     [music][key]sidechaincompress=threshold=0.05:ratio=3:attack=150:release=900[ducked];
     [vo][ducked]amix=inputs=2:duration=first:dropout_transition=0:normalize=0,
                 alimiter=limit=0.89,aresample=44100[out]" \
   -map "[out]" -c:a libmp3lame -q:a 2 voiceover-with-music.mp3
+# ↑ aformat (not bare aresample) on BOTH legs: ElevenLabs/tts often emit a MONO voiceover, and
+#   sidechaincompress aborts ("Failed to inject frame into filter network") if the key and music
+#   differ in channel layout. Forcing both to stereo/44.1k up front avoids it.
 
 # 5. Run quality gates + render
 npx hyperframes doctor
@@ -73,6 +76,12 @@ npx hyperframes inspect  . --samples 12
 npx hyperframes validate .
 mkdir -p out
 npx hyperframes render   . --output out/final.mp4 --quality high
+#   On WSL2 (and some sandboxed hosts) native render fails at
+#   "Protocol error (Page.captureScreenshot)"; add --docker to render in a container
+#   (needs Docker running): npx hyperframes render . --output out/final.mp4 --quality high --docker
+#   On machines with <=8 GB RAM, also add --no-low-memory-mode — low-memory mode forces the same
+#   screenshot capture that fails; it switches Docker back to beginframe capture:
+#   npx hyperframes render . --output out/final.mp4 --quality high --docker --no-low-memory-mode
 ```
 
 Render time: ~20–30s on a 16-core machine with hardware GPU.

--- a/workflows/phase-5-audio.md
+++ b/workflows/phase-5-audio.md
@@ -267,8 +267,8 @@ ffmpeg -y -i voiceover-normalized.mp3 -i background-music.mp3 \
          equalizer=f=2500:t=q:w=1:g=-3,
          afade=t=in:st=0:d=2,
          afade=t=out:st=${FADE_OUT_START}:d=4,
-         aresample=44100[music];
-    [0:a]aresample=44100,asplit=2[vo][key];
+         aformat=sample_fmts=fltp:sample_rates=44100:channel_layouts=stereo[music];
+    [0:a]aformat=sample_fmts=fltp:sample_rates=44100:channel_layouts=stereo,asplit=2[vo][key];
     [music][key]sidechaincompress=threshold=0.05:ratio=3:attack=150:release=900[ducked];
     [vo][ducked]amix=inputs=2:duration=first:dropout_transition=0:normalize=0,
                 alimiter=limit=0.89,
@@ -299,8 +299,13 @@ What each stage does — tune by ear, the numbers are starting points, not targe
   which *undoes the sidechain duck and fights the fades* — verified: with a dynamic master the music
   measures **louder** under speech than in the gaps. If you need to hit -16 LUFS more exactly,
   correct with a **constant** gain after validation (below), never a dynamic pass.
-- **`aresample=44100`** — the music-branch `loudnorm` can internally switch to 192 kHz; the explicit
-  resamples keep the `sidechaincompress`/`amix` inputs rate-matched and the MP3 encoder happy.
+- **`aformat=…:channel_layouts=stereo` on both legs (not `aresample`)** — `sidechaincompress`
+  requires its two inputs to share sample format, rate, **and channel layout**; ElevenLabs (and the
+  `hyperframes tts` fallback) often emit a **mono** voiceover, and mixing a mono key against a stereo
+  music bed makes the filter abort with `Error reinitializing filters! Failed to inject frame into
+  filter network`. `aformat` forces both legs to stereo/44.1k/fltp up front — a superset of the old
+  `aresample=44100` (which fixed only the rate). The music-branch `loudnorm` can also internally
+  switch to 192 kHz, so pinning the rate here keeps the `amix`/MP3 encoder happy too.
 
 **Critical:** keep `amix … normalize=0`. The default `normalize=1` divides each input by the input
 count (a hidden -6 dB per track), which would gut the already-quiet bed. Set level via the music
@@ -432,6 +437,7 @@ npx hyperframes doctor
 Known issues:
 
 - **`HeadlessExperimental.beginFrame' wasn't found`** — Chromium 147+ removed this protocol. The HyperFrames CLI from v0.4.2 onwards auto-detects and falls back to screenshot mode. If you're on a pinned older CLI, set the escape hatch: `export PRODUCER_FORCE_SCREENSHOT=true` before render.
+- **`Protocol error (Page.captureScreenshot): Unable to capture screenshot`** — the host's headless Chrome can't screenshot (observed on WSL2; can also hit sandboxed/container hosts). `doctor` passes and the composition compiles, but capture dies. Render in Docker instead — the CLI ships a containerized path: `npx hyperframes render . --output out/final.mp4 --docker` (needs Docker running; the first run pulls the image). On machines with ≤8 GB RAM the CLI auto-enables low-memory mode, which *forces the same screenshot capture* and can fail again inside Docker too — add `--no-low-memory-mode` to switch back to `beginframe` capture: `npx hyperframes render . --output out/final.mp4 --docker --no-low-memory-mode`. Output is identical.
 - **Render hangs ~120 seconds then times out** — HyperFrames is trying to use system Chrome instead of `chrome-headless-shell`. Fix:
   ```bash
   npx puppeteer browsers install chrome-headless-shell


### PR DESCRIPTION
## Summary

Two Phase 5 render-robustness fixes, surfaced by a real end-to-end render of the `example/` build to MP4. Kept **separate from #7** because #6 explicitly scopes out the rendering pipeline and `example/`.

Closes #8.

- **Mono-voiceover sidechain fix** — `aformat=…:channel_layouts=stereo` on both legs (was a bare `aresample=44100`). ElevenLabs / `hyperframes tts` often emit a mono voiceover, and `sidechaincompress` aborts (`Failed to inject frame into filter network`) when the key and music differ in channel layout. `workflows/phase-5-audio.md` + `example/README.md`.
- **WSL / low-memory render path** — native render can fail at `Protocol error (Page.captureScreenshot)`; documented `--docker`, plus `--no-low-memory-mode` on ≤8 GB machines (low-memory mode auto-forces the failing screenshot capture). Verified against HyperFrames `render --help` + rendering docs.

## Test plan

- [x] Re-ran the documented `aformat` ffmpeg mix command (rc=0)
- [x] Rendered `example/` to a valid 1920×1080 H.264+AAC 60s MP4 via `--docker`
- [x] Confirmed `--no-low-memory-mode` exists in `hyperframes render --help`