### PR TITLE
docs: mark Codex & Cursor manifests as experimental

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,11 @@ The CLI auto-detects which coding agents you have installed and resolves the cor
 
 For agents that load native plugins, per-agent manifests are provided at the repo root. Each points its skills source at `./` (the repo root holds `SKILL.md`), not `./skills/`:
 
-- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — Claude Code
-- `.codex-plugin/plugin.json` — Codex
-- `.cursor-plugin/plugin.json` — Cursor
+- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` — Claude Code (verified)
+- `.codex-plugin/plugin.json` — Codex (experimental — manifest provided, not yet verified end-to-end)
+- `.cursor-plugin/plugin.json` — Cursor (experimental — manifest provided, not yet verified end-to-end)
 
-All manifests are MIT-licensed, matching this repository.
+All manifests are MIT-licensed, matching this repository. End-to-end loading + render is currently proven on **Claude Code** and **GitHub Copilot CLI** only.
 
 ## Using the skill
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single CLI path with one manual git-clone fallback — the CLI auto-detects the agent and
   resolves its scanned skills home.
 
+### Documentation
+
+- **Codex & Cursor marked experimental.** The repo ships `.codex-plugin/` and
+  `.cursor-plugin/` manifests, but end-to-end loading + render is verified only on Claude Code
+  and GitHub Copilot CLI. `README.md` and `AGENTS.md` now label Codex/Cursor as
+  manifest-provided-but-unverified, instead of implying first-class support.
+
 ### Changed
 
 - **Phase 5 music mix now sits the soundtrack under the voice as a ducked bed.**

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ git clone https://github.com/nebrass/hve-spielberg.git ~/.claude/skills/hve-spie
 # GitHub Copilot CLI: clone into ~/.copilot/skills/hve-spielberg instead
 ```
 
+### Codex & Cursor (experimental)
+
+This repo also ships `.codex-plugin/` and `.cursor-plugin/` manifests, and `npx skills add` can install into those agents. **These integrations are provided but not yet verified end-to-end** — the skill loads and renders are proven on **Claude Code** and **GitHub Copilot CLI** only. Codex/Cursor should work (the skill body is agent-neutral and the manifests point at the root `SKILL.md`), but treat them as untested until a full Phase 0→5 run is confirmed on each. Reports welcome.
+
 ## Updating
 
 Already installed an older version? Update to the latest `main`:


### PR DESCRIPTION
## Summary

PR #7 shipped `.codex-plugin/` and `.cursor-plugin/` plugin manifests, but the skill is only verified end-to-end on **Claude Code** and **GitHub Copilot CLI**. The docs implied broader support than was tested. This aligns the docs with reality.

- `README.md` — new "Codex & Cursor (experimental)" subsection under Installation: manifests provided, not yet verified end-to-end.
- `AGENTS.md` — manifest list labels Claude as *verified*, Codex/Cursor as *experimental*; notes end-to-end is proven on Claude Code + Copilot CLI only.
- `CHANGELOG.md` — `### Documentation` note under `[Unreleased]`.

Headline left naming the two verified agents (now accurate, with the experimental note below it).

## Test plan

- [x] No code/manifest changes — docs only
- [ ] (Follow-up) A real Phase 0→5 run on Codex and Cursor would let us promote them from experimental to verified