### PR TITLE
docs: document native OpenCode + Pi skill discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ For agents that load native plugins, per-agent manifests are provided at the rep
 
 All manifests are MIT-licensed, matching this repository. End-to-end loading + render is currently proven on **Claude Code** and **GitHub Copilot CLI** only.
 
+**OpenCode** and **Pi** need no manifest — both discover skills by directory convention and read the same Agent Skills `SKILL.md` format. OpenCode scans `.claude/skills/`, `~/.claude/skills/`, `.agents/skills/`, `~/.agents/skills/`, `.opencode/skills/`, `~/.config/opencode/skills/`; Pi scans `~/.pi/agent/skills/`, `~/.agents/skills/`, `.pi/skills/`, and project `.agents/skills/` (once trusted). `npx skills add nebrass/hve-spielberg` installs a `<name>/SKILL.md` subdir into a scanned home, so both pick it up natively (see the OpenCode & Pi section in [`README.md`](README.md)). Skill loading follows each agent's documented convention; a full Phase 0→5 run on OpenCode/Pi is not yet verified.
+
 ## Using the skill
 
 Once installed, start it with `/hve-spielberg` (a slash command on Claude Code; invoke by name or intent on GitHub Copilot CLI — run `/skills` there to confirm it loaded). It runs a 6-phase video production pipeline — see [`SKILL.md`](SKILL.md) and [`README.md`](README.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the hand-paired `~/.claude` / `~/.copilot` git-clone and `cp -r` install blocks into a
   single CLI path with one manual git-clone fallback — the CLI auto-detects the agent and
   resolves its scanned skills home.
+- **OpenCode & Pi support (documented).** Both agents discover skills by directory
+  convention and read the same Agent Skills `SKILL.md` format. OpenCode scans
+  `.claude/skills/`, `~/.claude/skills/`, `.agents/skills/`, `~/.agents/skills/`,
+  `.opencode/skills/`, `~/.config/opencode/skills/`; Pi scans `~/.pi/agent/skills/`,
+  `~/.agents/skills/`, `.pi/skills/`, and project `.agents/skills/` (once trusted).
+  Since `npx skills add nebrass/hve-spielberg` already installs a `<name>/SKILL.md`
+  subdir into a scanned home, no plugin or `package.json` is needed — both pick the
+  skill up natively and load it on demand. Documented in `README.md` and `AGENTS.md`.
+  Skill *loading* follows each agent's documented convention; a full Phase 0→5 run on
+  OpenCode/Pi is not yet verified (proven on Claude Code and GitHub Copilot CLI).
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ git clone https://github.com/nebrass/hve-spielberg.git ~/.claude/skills/hve-spie
 
 This repo also ships `.codex-plugin/` and `.cursor-plugin/` manifests, and `npx skills add` can install into those agents. **These integrations are provided but not yet verified end-to-end** — the skill loads and renders are proven on **Claude Code** and **GitHub Copilot CLI** only. Codex/Cursor should work (the skill body is agent-neutral and the manifests point at the root `SKILL.md`), but treat them as untested until a full Phase 0→5 run is confirmed on each. Reports welcome.
 
+### OpenCode & Pi (native discovery)
+
+No plugin needed — both **OpenCode** and **Pi** discover skills by directory convention and read the same Agent Skills `SKILL.md` format. The skills-CLI install above writes to a home each one scans, so they pick up hve-spielberg natively:
+
+```bash
+npx skills add nebrass/hve-spielberg            # project (.agents/skills/)
+npx skills add nebrass/hve-spielberg --global   # global
+```
+
+- **OpenCode** scans `.claude/skills/`, `~/.claude/skills/`, `.agents/skills/`, `~/.agents/skills/`, `.opencode/skills/`, `~/.config/opencode/skills/`. Troubleshooting: <https://opencode.ai/docs/skills/>.
+- **Pi** scans `~/.pi/agent/skills/`, `~/.agents/skills/` (global) and `.pi/skills/`, `.agents/skills/` (project, after the project is *trusted*). Pi discovers `<name>/SKILL.md` subdirectories — which is exactly what `npx skills add` creates. Troubleshooting: <https://pi.dev/docs/latest/skills>.
+
+Then ask for a video (e.g. "make a showcase video of this app") — the agent loads the skill on demand. Skill *loading* follows each agent's documented convention; a full Phase 0→5 run on OpenCode/Pi is **not yet verified** (end-to-end render is proven on Claude Code and GitHub Copilot CLI).
+
 ## Updating
 
 Already installed an older version? Update to the latest `main`:


### PR DESCRIPTION
## Summary

Documents **OpenCode** and **Pi** support — docs-only, no repo files needed. Both discover skills by **directory convention** and read the same Agent Skills `SKILL.md` format (per [OpenCode docs](https://opencode.ai/docs/skills/) and [Pi docs](https://pi.dev/docs/latest/skills)).

`npx skills add nebrass/hve-spielberg` installs a `<name>/SKILL.md` subdir into a home each agent scans (`.agents/skills/`, `~/.claude/skills/`, etc.), so **both pick up hve-spielberg natively — no plugin, no `package.json`, no `.opencode/`/`.pi/` files.**

- **OpenCode** scans `.claude/skills/`, `~/.claude/skills/`, `.agents/skills/`, `~/.agents/skills/`, `.opencode/skills/`, `~/.config/opencode/skills/`.
- **Pi** scans `~/.pi/agent/skills/`, `~/.agents/skills/`, `.pi/skills/`, project `.agents/skills/` (once trusted). It discovers `<name>/SKILL.md` subdirs — exactly what the skills CLI creates.

`hve-spielberg` is a valid Agent-Skills name (`^[a-z0-9]+(-[a-z0-9]+)*$`, folder matches `name`), so it satisfies both agents' validators.

## History

Started as an OpenCode in-process plugin, then the official docs showed discovery is pure convention — plugin + `package.json` + `.opencode/` all removed. Pi turned out to be the same case (my earlier "Pi needs an extension" assumption was wrong — that's only for superpowers-style bootstrap injection, not discovery).

Net: **3 doc files, +30/−4.** README / AGENTS.md / CHANGELOG.

## Status

- [x] Skill *loading* follows both agents' documented conventions
- [ ] **Not yet verified:** full Phase 0→5 run on OpenCode or Pi (proven on Claude Code + Copilot CLI)