### PR TITLE
fix(skill): make creative selections user-owned, not agent-inferred

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -22,6 +22,16 @@ You also understand **design thinking** — you don't just make videos, you firs
 
 Your creative instincts guide every decision. The guidelines below are suggestions, not rules.
 
+**But creative instinct governs *craft*, not the user's *choices*.** You decide the motion, easing,
+polish, and composition. The user decides the **brief**: video mode, whether to film the real
+product, duration, theme, aspect ratio, visual identity / design system, voiceover, section
+transitions, and music. Those are **user-owned selections** — wherever a phase presents one as a
+`{"questions": [...]}` block, you **must** surface it as a native prompt and let the user pick. Do
+**not** silently infer, default, or self-answer them from your Phase-0 analysis, however confident
+you are; a deep read of the codebase tells you what to *recommend*, never what to *decide on their
+behalf*. Presenting the choice (with a smart default pre-highlighted) takes seconds and is the
+difference between "the tool made a video" and "the tool made *my* video."
+
 ## Runtime Compatibility
 
 This skill is **agent-agnostic** — it runs on both **Claude Code** and **GitHub Copilot CLI**.

--- a/workflows/phase-0-discovery.md
+++ b/workflows/phase-0-discovery.md
@@ -110,4 +110,8 @@ Generate `context.md` from `templates/context.md` with all gathered information.
 > "Discovery complete. Here's what I understand about your product and audience:
 > [Summary of context.md]
 >
+> Next, Phase 1 is where **you** choose how the video looks and sounds — visual identity / design
+> system, duration, theme, aspect ratio, voice, and transitions. I'll recommend options based on
+> what I found, but the picks are yours.
+>
 > Ready to move to Phase 1: Storytelling?"

--- a/workflows/phase-1-storytelling.md
+++ b/workflows/phase-1-storytelling.md
@@ -2,6 +2,27 @@
 
 Build the narrative structure and visual plan. Reads `context.md` from Phase 0.
 
+## The creative brief — user-owned selections (present them, don't decide them)
+
+This phase collects the choices that define how the video looks and sounds. **These are the
+user's to make, not yours to infer** (see `SKILL.md` § "creative instinct governs craft, not the
+user's choices"). Steps 1.1–1.5 each present a `{"questions": [...]}` block — you **must** surface
+every one as a native prompt, even when your Phase-0 analysis makes the "obvious" choice feel
+settled. Pre-highlight a smart default and say why you recommend it, but let the user pick. The
+levers, in order:
+
+| Step | Choice | Never skip because… |
+|---|---|---|
+| 1.1 | Duration · Theme (light/dark) · Aspect ratio | "it's obviously a 60s 16:9" — the user may want a 9:16 short |
+| 1.2 | **Visual identity / design system** (10 brands, a named style, or derive) | "it's a dev tool, so Vercel" — brand is the single most visible choice; always show the picker |
+| 1.3 | Voiceover voice | "Matilda is the default" — voice sets the whole tone |
+| 1.5 | Section transition · speed | "crossfade is fine" — the user may want the branded swoosh |
+
+Present them as a short sequence (or, if your runtime supports multi-question prompts, batch 1.1
+together as shown). Record every answer in `project-plan.md`. Do not advance to the storyboard
+until the identity (Step 1.2) and voice (Step 1.3) are chosen — a storyboard written before the
+brand is picked bakes in the wrong look.
+
 ## Step 1.1: Duration & Theme
 
 ```json
@@ -45,7 +66,11 @@ Record the choice in `project-plan.md`. Phase 3 scene templates and the Phase 4 
 
 ## Step 1.2: Visual Identity (3 strategies)
 
-Three ways to lock in the visual identity. Pick the most specific one that fits — each is faster than the next.
+The single most visible choice in the whole video. **Always present this picker** — never
+pre-select a strategy or a brand on the user's behalf from your Phase-0 read (that's the exact
+"agent silently picked Vercel" failure). You may *recommend* one (e.g. "your commits look like a
+dev tool — Vercel or Linear would fit") and pre-highlight it, but the user chooses. Three ways to
+lock in the identity:
 
 ```json
 {
@@ -53,14 +78,17 @@ Three ways to lock in the visual identity. Pick the most specific one that fits 
     "question": "How should the visual identity be set?",
     "header": "Identity",
     "options": [
-      { "label": "Use a curated design system (fastest)", "description": "Pick a known brand: Stripe, Linear, Apple, Notion, Vercel, Airbnb, GitHub, Cal, Arc, Bento. Skips brand extraction entirely; Phase 3 copies design-systems/<name>/DESIGN.md straight into the project. Best when the user says 'make it look like X'." },
-      { "label": "Pick a HyperFrames named style (medium)", "description": "Pick from 8 styles: Swiss Pulse, Velvet Standard, Deconstructed, Maximalist Type, Data Drift, Soft Signal, Folk Frequency, Shadow Cut. Phase 3 seeds the project's DESIGN.md from the named style; still allows minor screenshot-based tuning." },
-      { "label": "Derive from screenshots (default)", "description": "Phase 3 extracts colors, typography, and shape language from the captured app screenshots. Best when the user wants an identity that matches their actual product." }
+      { "label": "Use a curated design system", "description": "Pick a known brand: Stripe, Linear, Apple, Notion, Vercel, Airbnb, GitHub, Cal, Arc, Bento. Phase 3 copies design-systems/<name>/DESIGN.md straight into the project. Best when you want a specific brand's look." },
+      { "label": "Pick a HyperFrames named style", "description": "Pick from 8 styles: Swiss Pulse, Velvet Standard, Deconstructed, Maximalist Type, Data Drift, Soft Signal, Folk Frequency, Shadow Cut. Phase 3 seeds DESIGN.md from the named style; still allows minor screenshot-based tuning." },
+      { "label": "Derive from the captured screenshots", "description": "Phase 3 extracts colors, typography, and shape language from the app's own screenshots. Best when you want the video to match the product's existing look exactly." }
     ],
     "multiSelect": false
   }]
 }
 ```
+
+**If "Use a curated design system" is chosen**, immediately present the brand picker below — do not
+pick a brand yourself.
 
 ### If "curated design system" was picked
 


### PR DESCRIPTION
Closes #14.

## Problem

The pipeline already defines pickers for the key creative choices — visual identity / design system (10 brands), theme, aspect ratio, voice, section transitions, music — but nothing made the agent **surface** them. A confident agent (fresh off a Phase-0 codebase analysis) would infer *"dev tool → Vercel, light, Matilda"* and proceed without ever showing the user the choices. The output then feels like "the tool made *a* video" rather than "the tool made *my* video."

Root cause is enforcement, not missing questions. Three nudges licensed the skip:
1. `SKILL.md` — *"Your creative instincts guide every decision. The guidelines below are suggestions, not rules."*
2. `phase-1-storytelling.md` Step 1.2 — *"pick the most specific one — each is faster"*, and *Derive from screenshots* tagged **"(default)"**.
3. No consolidated "here are your creative levers" moment; Phase 0 handed off without signalling the choices are the user's.

## Fix (doctrine/UX — a prompt-driven skill has no code gate for "did the agent show the picker", so the lever is explicit, repeated instruction)

- **`SKILL.md`** — split creative *craft* (agent's: motion, easing, polish) from the *brief* (user's: mode, product-surface, duration, theme, aspect, **identity / design system**, voice, transitions, music). The brief selections **must** be surfaced as prompts; the agent may *recommend* but never *decide on the user's behalf*.
- **`workflows/phase-1-storytelling.md`** — new **"creative brief"** contract at the top: a table of every lever with a "never skip because…" reason, plus "don't advance to the storyboard until identity + voice are chosen." Step 1.2 rewritten to **always present the picker**; removed the "(default)/(fastest)" skip nudges.
- **`workflows/phase-0-discovery.md`** — the checkpoint now tells the user *"Phase 1 is where **you** choose how it looks and sounds."*

Design-system choice **stays in Phase 1** (made non-skippable), not moved to Phase 0 — per the decision on #14.

## Scope / non-goals

Isolated to the creative-choice UX. Does **not** touch the separate flat-output / real-product-spine work or the flagship rebuild (those are held on a different branch). +46/−4 across 3 files.

## Test plan

- [ ] Dry-run `/hve-spielberg` on a sample repo and confirm the agent presents the identity/design-system picker (Step 1.2) and voice picker (Step 1.3) instead of inferring them.
- [ ] Confirm the brief table's Step references (1.1–1.5) resolve to real headings.
- [ ] Confirm no `{"questions":[...]}` block is printed as raw JSON (runtime renders it as a native prompt).