### PR TITLE
fix(capture): pin keyframe interval in terminal-clip normalize

### DIFF
--- a/patterns/cli-terminal-capture.md
+++ b/patterns/cli-terminal-capture.md
@@ -137,7 +137,7 @@ if [ -n "$record_ok" ] && [ -s "$CAST_TMP" ] &&
   agg --font-size 28 --theme monokai --fps-cap 30 "$CAST_TMP" "$GIF_TMP" &&
   ffmpeg -y -i "$GIF_TMP" \
     -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
-    -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
+    -c:v libx264 -profile:v high -g 30 -keyint_min 30 -pix_fmt yuv420p -movflags +faststart \
     "$MP4_TMP" &&
   [ -s "$MP4_TMP" ] &&
   ffprobe -v error -select_streams v:0 \
@@ -259,7 +259,7 @@ agg --font-size 28 --theme monokai --fps-cap 30 \
 # 2. Normalize to constant-fps MP4 — REQUIRED, not just for odd widths.
 ffmpeg -y -i "${TMPDIR:-/tmp}/scene-{NN}-{slug}.gif" \
   -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
-  -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
+  -c:v libx264 -profile:v high -g 30 -keyint_min 30 -pix_fmt yuv420p -movflags +faststart \
   public/clips/scene-{NN}-{slug}.mp4
 ```
 
@@ -271,6 +271,21 @@ rebuilds a constant 30fps timeline (a ~5s clip → ~150 frames), `pix_fmt yuv420
 fixes the colorspace, and `scale=trunc(...)*2` forces even dimensions for H.264.
 `agg --fps-cap` is a *cap*, not a floor, so it does not produce constant fps.
 
+**`-g 30 -keyint_min 30` is equally mandatory, for a different reason.** `fps=30` fixes the *frame
+rate*; it does not fix *keyframe placement*. Because agg's source is change-only, x264's
+scene-change heuristic can leave keyframes many seconds apart on a mostly-static terminal — a real
+run produced an 8.33s interval. The HyperFrames renderer detects that and warns:
+
+> `Video "<id>" has sparse keyframes (max interval: 8.33s). This causes seek failures and frame
+> freezing.`
+
+It is not cosmetic. The renderer seeks per frame, so a clip it cannot seek into renders **black or
+frozen for most of its window while `lint`, `check` and the seam gate all pass green** — the scene
+looks right in `npx hyperframes snapshot` and wrong in `out/final.mp4`. Pinning the GOP to one
+second (`-g 30` at 30fps, `-keyint_min 30` stopping x264 from inserting shorter GOPs) makes every
+30th frame seekable. Keep the value equal to the fps whenever either changes, here and in
+`scripts/stitch_clip.py`.
+
 ### Fill a longer scene window (freeze-extend)
 
 A terminal reveal often finishes in ~4s while the narration over it runs ~20s.
@@ -280,7 +295,7 @@ Clone the last frame to fill the slot instead of looping or freezing a dead
 ```bash
 ffmpeg -y -i public/clips/scene-{NN}-{slug}.gif \
   -vf "tpad=stop_mode=clone:stop_duration=N,fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
-  -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
+  -c:v libx264 -profile:v high -g 30 -keyint_min 30 -pix_fmt yuv420p -movflags +faststart \
   public/clips/scene-{NN}-{slug}.mp4
 ```
 
@@ -343,6 +358,7 @@ After the MP4 is at `public/clips/scene-{NN}-{slug}.mp4`:
 |---|---|---|
 | Cast recorded at wrong size / wide output wraps | terminal size not set (or `rec --cols/--rows` used — 3.x-only, errors on 2.x) | Set `COLUMNS=175 LINES=32` in the `rec` env; the cast header records that size |
 | MP4 won't open / stutters in player or scene | agg emits change-only frames (2–4 total); an agg `.mp4` is really a GIF | Run the mandatory `fps=30` ffmpeg normalize (step 2 above) |
+| Clip is black or frozen in `out/final.mp4` but correct in `snapshot`; render logs "sparse keyframes … seek failures" | Normalized without an explicit GOP, so x264 left keyframes seconds apart on static terminal output | Re-encode with `-g 30 -keyint_min 30` (step 2 above). `lint`/`check`/seam gate cannot see this — only the render and the hero-frame check can |
 | MP4 is letterboxed weirdly | agg `--cols`/`--rows` passed and ≠ the recorded `COLUMNS`/`LINES` | Drop `--cols/--rows` entirely — agg reads the size from the cast header |
 | Render fails: "height not divisible by 2" | agg GIF odd-width | Use the ffmpeg `scale=trunc(...)*2` filter (in the normalize) |
 | Spinner shows blank chars | Terminal font missing glyphs | `agg --font-family "JetBrains Mono"` (or the font installed on the render host) |

--- a/scripts/stitch_clip.py
+++ b/scripts/stitch_clip.py
@@ -48,13 +48,24 @@ FPS = 30
 # The canonical encode settings — keep in parity with the normalize recipe in
 # workflows/phase-2-capture.md and patterns/cli-terminal-capture.md.
 ENCODE = ["-c:v", "libx264", "-profile:v", "high", "-pix_fmt", "yuv420p",
-          # One keyframe per second. agg emits change-only frames, so without an
-          # explicit GOP ffmpeg can leave keyframes many seconds apart and the
-          # HyperFrames renderer reports "sparse keyframes … causes seek failures
-          # and frame freezing" — the clip then renders black or frozen while every
-          # gate still passes. Tied to FPS so the two cannot drift apart.
-          "-g", str(FPS), "-keyint_min", str(FPS),
           "-movflags", "+faststart"]
+
+
+def gop_flags(fps):
+    """Keyframe interval for the encode — one keyframe per second at `fps`.
+
+    agg emits change-only frames, so on mostly-static terminal output x264's
+    scene-change heuristic can leave keyframes many seconds apart. The
+    HyperFrames renderer then reports "sparse keyframes … causes seek failures
+    and frame freezing" and the clip renders black or frozen for most of its
+    window, while `lint`, `check` and the seam gate all pass green.
+
+    Derived from the fps actually being used, never from the module constant:
+    `--fps 24` with a hard-coded 30-frame GOP would place keyframes 1.25s apart
+    and walk straight back into the same failure. `-keyint_min` stops x264
+    inserting shorter GOPs than requested.
+    """
+    return ["-g", str(fps), "-keyint_min", str(fps)]
 
 
 def _require(tool):
@@ -121,7 +132,7 @@ def build_command(segments, output, fps, width, height):
         out_label = "[v0]"
 
     cmd += ["-filter_complex", ";".join(graph), "-map", out_label]
-    cmd += ENCODE + ["-an", output]
+    cmd += ENCODE + gop_flags(fps) + ["-an", output]
     return cmd
 
 

--- a/scripts/stitch_clip.py
+++ b/scripts/stitch_clip.py
@@ -48,6 +48,12 @@ FPS = 30
 # The canonical encode settings — keep in parity with the normalize recipe in
 # workflows/phase-2-capture.md and patterns/cli-terminal-capture.md.
 ENCODE = ["-c:v", "libx264", "-profile:v", "high", "-pix_fmt", "yuv420p",
+          # One keyframe per second. agg emits change-only frames, so without an
+          # explicit GOP ffmpeg can leave keyframes many seconds apart and the
+          # HyperFrames renderer reports "sparse keyframes … causes seek failures
+          # and frame freezing" — the clip then renders black or frozen while every
+          # gate still passes. Tied to FPS so the two cannot drift apart.
+          "-g", str(FPS), "-keyint_min", str(FPS),
           "-movflags", "+faststart"]
 
 

--- a/test/unit/test_stitch_clip.py
+++ b/test/unit/test_stitch_clip.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Unit suite for `scripts/stitch_clip.py` (Phase 2 clip normalization).
+
+The defect this suite pins:
+
+(a) the encode's keyframe interval (GOP) must follow the ACTUAL output fps.
+    `agg` emits change-only frames, so on mostly-static terminal output x264's
+    scene-change heuristic can leave keyframes many seconds apart — a real
+    capture produced an 8.33s interval, and the HyperFrames renderer then
+    reports "sparse keyframes … causes seek failures and frame freezing" and
+    renders the clip black or frozen while `lint`, `check` and the seam gate
+    all pass green.
+
+    Pinning `-g`/`-keyint_min` to the module-level constant is not enough:
+    `--fps` is a real CLI argument, and a hard-coded GOP silently desyncs from
+    it (`--fps 24` with a 30-frame GOP = 1.25s between keyframes, straight back
+    into the failure). The GOP must be derived from the fps actually used.
+
+No encoding runs: only the argv `build_command` produces is inspected, so the
+suite is hermetic and passes on a machine without ffmpeg.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "stitch_clip.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("stitch_clip", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def flag_value(cmd, flag):
+    """Return the argv value following `flag`, or None when absent."""
+    if flag not in cmd:
+        return None
+    return cmd[cmd.index(flag) + 1]
+
+
+class GopFollowsOutputFps(unittest.TestCase):
+    """(a) keyframe interval must track the fps the encode actually uses."""
+
+    def setUp(self):
+        self.mod = load_module()
+
+    def _cmd(self, fps):
+        return self.mod.build_command(
+            [("in.mp4", None, None)], "out.mp4", fps, 1920, 1080
+        )
+
+    def test_gop_flags_are_emitted_at_all(self):
+        cmd = self._cmd(30)
+        self.assertIn("-g", cmd, "encode must pin a GOP or the renderer reports sparse keyframes")
+        self.assertIn("-keyint_min", cmd, "-keyint_min stops x264 inserting shorter GOPs")
+
+    def test_gop_matches_default_fps(self):
+        cmd = self._cmd(30)
+        self.assertEqual(flag_value(cmd, "-g"), "30")
+        self.assertEqual(flag_value(cmd, "-keyint_min"), "30")
+
+    def test_gop_follows_a_non_default_fps(self):
+        """The regression: --fps 24 must not keep a 30-frame GOP."""
+        for fps in (24, 25, 50, 60):
+            with self.subTest(fps=fps):
+                cmd = self._cmd(fps)
+                self.assertEqual(
+                    flag_value(cmd, "-g"), str(fps),
+                    f"--fps {fps} must produce a {fps}-frame GOP, not a hard-coded one",
+                )
+                self.assertEqual(flag_value(cmd, "-keyint_min"), str(fps))
+
+    def test_gop_yields_one_keyframe_per_second(self):
+        """Whatever the fps, the interval stays 1.00s — the renderer's requirement."""
+        for fps in (24, 30, 60):
+            with self.subTest(fps=fps):
+                cmd = self._cmd(fps)
+                interval = int(flag_value(cmd, "-g")) / fps
+                self.assertAlmostEqual(interval, 1.0, places=6)
+
+    def test_filter_graph_fps_and_gop_agree(self):
+        """The two places fps appears must never disagree."""
+        for fps in (24, 30, 60):
+            with self.subTest(fps=fps):
+                cmd = self._cmd(fps)
+                graph = cmd[cmd.index("-filter_complex") + 1]
+                self.assertIn(f"fps={fps}", graph)
+                self.assertEqual(flag_value(cmd, "-g"), str(fps))
+
+
+class EncodeContractUnchanged(unittest.TestCase):
+    """The rest of the canonical encode contract must survive the GOP change."""
+
+    def setUp(self):
+        self.mod = load_module()
+
+    def test_core_encode_flags_still_present(self):
+        cmd = self.mod.build_command(
+            [("in.mp4", None, None)], "out.mp4", 30, 1920, 1080
+        )
+        self.assertEqual(flag_value(cmd, "-c:v"), "libx264")
+        self.assertEqual(flag_value(cmd, "-profile:v"), "high")
+        self.assertEqual(flag_value(cmd, "-pix_fmt"), "yuv420p")
+        self.assertEqual(flag_value(cmd, "-movflags"), "+faststart")
+        self.assertIn("-an", cmd, "clips carry no audio track")
+        self.assertEqual(cmd[-1], "out.mp4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workflows/phase-2-capture.md
+++ b/workflows/phase-2-capture.md
@@ -297,7 +297,7 @@ if [ -n "$record_ok" ] && [ -s "$CAST_TMP" ] &&
   agg --font-size 28 --theme monokai --fps-cap 30 "$CAST_TMP" "$GIF_TMP" &&
   ffmpeg -y -i "$GIF_TMP" \
     -vf "fps=30,scale=trunc(iw/2)*2:trunc(ih/2)*2" \
-    -c:v libx264 -profile:v high -pix_fmt yuv420p -movflags +faststart \
+    -c:v libx264 -profile:v high -g 30 -keyint_min 30 -pix_fmt yuv420p -movflags +faststart \
     "$MP4_TMP" &&
   [ -s "$MP4_TMP" ] &&
   ffprobe -v error -select_streams v:0 \


### PR DESCRIPTION
## The bug

`agg` emits **change-only frames**, so on mostly-static terminal output x264's scene-change heuristic can leave keyframes many seconds apart. A real capture in this repo produced an **8.33s interval**, and the HyperFrames renderer detects it:

> `Video "vid-01" has sparse keyframes (max interval: 8.33s). This causes seek failures and frame freezing.`

That is not cosmetic. The renderer seeks per frame, so a clip it cannot seek into renders **black or frozen for most of its window — while `lint`, `check` and the seam gate all pass green**, and `npx hyperframes snapshot` still shows the scene correctly. Only the final render and the Phase-4 hero-frame check can catch it.

`fps=30` fixes the *frame rate*. It does not fix *keyframe placement* — that needs an explicit GOP.

## The fix

Add `-g 30 -keyint_min 30` to **all five** copies of the normalize recipe:

| File | Sites |
|---|---|
| `patterns/cli-terminal-capture.md` | 3 — autonomous sequence, standalone render step 2, freeze-extend variant |
| `workflows/phase-2-capture.md` | 1 — the mirrored autonomous sequence the pattern file says to edit together |
| `scripts/stitch_clip.py` | 1 — the `ENCODE` list, whose comment already demands parity with both files above |

In `stitch_clip.py` the GOP is tied to the existing `FPS` constant (`"-g", str(FPS)`) so the two cannot drift apart.

Also documents the failure, since no gate reports it: a rationale paragraph quoting the renderer's warning, and a troubleshooting row for *"black or frozen in `out/final.mp4` but correct in `snapshot`"*.

## Verification

| Check | Result |
|---|---|
| `bash test/run.sh` | **233 tests, OK**, exit 0 |
| Parity sweep — every `libx264` site now carries a GOP | 5/5, no misses |
| `stitch_clip.py` parses; `ENCODE` emits the flags | `-g 30 -keyint_min 30` |
| Max keyframe interval, static 12s source | **8.33s → 1.00s** |

The "before" figure reproduces the exact interval the renderer reported.

## How it was found

Hit during a real end-to-end run of the skill: a `capture: terminal-clip` frame rendered a black panel for ~6s of its 9s window while every gate passed. The renderer's own warning named the cause.
