### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "hve-video-director",
       "source": "./",
       "description": "End-to-end video production pipeline with design thinking. A 6-phase orchestrator (Discovery → Storytelling → Capture → Design → Production → Audio & Render) that turns your app into a polished promo, showcase, or tutorial video, rendered with HyperFrames (HTML + GSAP). Runs on Claude Code and GitHub Copilot CLI.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "homepage": "https://github.com/nebrass/hve-video-director",
       "license": "MIT",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hve-video-director",
   "description": "End-to-end video production pipeline with design thinking. A 6-phase orchestrator (Discovery → Storytelling → Capture → Design → Production → Audio & Render) that turns your app into a polished promo, showcase, or tutorial video, rendered with HyperFrames (HTML + GSAP). Runs on Claude Code and GitHub Copilot CLI.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Nebrass Lamouchi",
     "email": "lnibrass@gmail.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-04
+
+Rebases the skill on the **HyperFrames ecosystem** ([#34](https://github.com/nebrass/hve-video-director/pull/34), milestones M0–M6). The finding behind it: roughly 70–85% of the phase prose had drifted into a hand-maintained shadow copy of the upstream manual, while the ecosystem had shipped real owners for nearly all of it. This release deletes the shadow copy and keeps the layer that has no upstream equivalent — the consent doctrine, revision fingerprints, capture determinism, and reviewed captions.
+
+No generated project is stranded: nothing is gated on the storyboard's shape, and a project created before this release still resumes.
+
+### Added
+
+- **The reasoning layer** (M1) — `reasoning/` and `grammar/` are first-class skill directories, not documentation. `reasoning/scene-analysis.md` owns the twelve per-frame questions, the closed set of director keys, and — single-sourced — the cognitive-load budgets. `reasoning/capability-catalog.md` owns and versions the capability-tag vocabulary and turns a frame's derived tags into a runtime. `grammar/camera.md`, `motion.md`, `metaphors.md` and `three-taxonomy.md` supply the vocabulary those stages choose from.
+- **`compat/ecosystem.md` — the compatibility thin waist** (ADR-007). The only file in the repo permitted to hold intra-skill paths for ecosystem skills: capability symbols, the CLI surface, behavior probes, and the pin/update policy. Everywhere else names a skill plus a capability SYMBOL and lets that map resolve it, so an upstream relayout is a one-row edit. Enforced in both directions by `test/unit/test_compat_pointers.py`.
+- **Frame packets** (M5) — a scene builder now receives one ephemeral packet per frame (that frame's storyboard block verbatim with its director keys, `DESIGN.md`, the inlined bodies of the recipes it cites, the builder role, and the bound capture paths) and returns exactly one scene file. Packets are regenerated every run and never committed. Role delta: `sub-agents/scene-builder-delta.md`.
+- **A numeric seam gate** (M3) — transition quality was previously enforced by prose DON'Ts. Phase 4 now writes a seam ledger, stamps the master seams from it (`SEAM_STAMP`), and verifies them (`SEAM_VERIFIER`, `motion-doctrine`). Velocity-matched cuts become checkable ledger rows; dissolves cannot be ledger rows, and Phase 4 reports the unverified boundary count either way.
+- **The official storyboard shape** (M4) — generated `storyboard.md` adopts `STORYBOARD_FORMAT`, buying the upstream parser, the Studio contact-sheet review, and the structured `.hyperframes/frame-comments.json` feedback channel. This skill's own keys ride along as extra bullets and are preserved verbatim; the `STORYBOARD_EXTRA_KEYS` probe guards that assumption in `bash test/run.sh`. `validate_brief.py storyboard --json` reports a project's shape, and `migrate-storyboard` converts one **only when the user asks**, preserving the original alongside it.
+- **Architecture decision records** ADR-001…ADR-008, plus the 29-section design review that produced them.
+
+### Changed
+
+- **Phase-5 audio generation is delegated** to the `media-use` audio engine (M2) — narration, music bed and SFX from one request. Delegation stops at generation: the exact-track music confirmation, the caption review state machine, the verified mix recipes, and render approval remain this skill's governance (ADR-001).
+- **`npx hyperframes check` is the required final gate**; `validate`, `inspect` and `layout` are deprecated aliases that announce themselves under `--json`.
+- **`example/` is regenerated** as a real end-to-end run against the HyperFrames-first pipeline, with every per-phase approval given by a human. Its `.hve/brief-state.json` is the consent record that makes the claim checkable.
+- **`BRIEF_FORMAT` was deliberately NOT adopted.** Its companion contract skips questions the request already answers, which contradicts this skill's consent doctrine — recommend, never preselect. `project-plan.md` remains the Creative Brief and the single record of the levers the user owns.
+
+### Removed
+
+- **The local acquisition fallbacks** (M6). `generate_voiceover.py` loses its ElevenLabs half and its Whisper verification pass; the file itself survives and must not be deleted, because `--assemble-only` is the section assembler **both** audio paths still use. With no engine installed, narration is `npx hyperframes tts` on an explicitly confirmed local voice and the music bed is user-provided.
+
+### Fixed
+
+- **Sparse keyframes in normalized terminal clips** ([#35](https://github.com/nebrass/hve-video-director/pull/35)). `agg` emits change-only frames, so on mostly-static terminal output x264 could leave keyframes many seconds apart — a real capture produced an 8.33s interval, and the renderer then reports `sparse keyframes … causes seek failures and frame freezing` and renders the clip black or frozen **while `lint`, `check` and the seam gate all pass green**. The normalize recipe now pins `-g`/`-keyint_min` to the output fps in all five places it appears, and `scripts/stitch_clip.py` derives the GOP from its `--fps` argument so the two cannot desync. New `test/unit/test_stitch_clip.py` pins the interval at 24/25/30/50/60 fps.
+
 ## [0.1.0] - 2026-07-26
 
 ### Changed — BREAKING
@@ -355,7 +385,8 @@ Initial release of the hve-video-director skill.
   earlier Pixabay integration.
 - README with install instructions and an MIT license.
 
-[Unreleased]: https://github.com/nebrass/hve-video-director/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/nebrass/hve-video-director/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/nebrass/hve-video-director/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/nebrass/hve-video-director/compare/v0.0.4...v0.1.0
 [0.0.4]: https://github.com/nebrass/hve-video-director/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/nebrass/hve-video-director/compare/v0.0.2...v0.0.3

--- a/README.md
+++ b/README.md
@@ -15,16 +15,18 @@ pipeline remains unverified.
 
 ## Reference build
 
-**The committed reference project is being regenerated.** The v0.1.0 demo project was built against
-the pipeline as it stood before the skill was rebased on the HyperFrames ecosystem, so it no longer
-demonstrates how the skill works today, and it was removed rather than left in the tree as a
-misleading example. The rendered videos below are unaffected — they are hosted artifacts, not
-working-tree files.
+**[`example/`](example/) is the committed reference build**, regenerated in v0.2.0 against the
+HyperFrames-first pipeline: `context.md`, `storyboard.md` in the official shape, `DESIGN.md`, eight
+scenes, the seam `ledger.json`, and the root `index.html`. Media is gitignored; the MP4 ships as a
+Release asset.
 
-Regenerating the reference is deliberately a **human-in-the-loop run**: every phase of this pipeline
-ends at a user-approval checkpoint, and no agent may grant one on your behalf. The rebuild also
-needs real text-to-speech, a licensed music track, and a headless-Chromium render. That is a
-production run someone sits through, not a build step.
+It is a **record, not a fixture**, and it is only worth anything while every byte is what the
+pipeline actually emitted. Producing one is a **human-in-the-loop run**: every phase ends at a
+user-approval checkpoint that no agent may grant on your behalf (ADR-001), and it needs real
+text-to-speech, a licensed music track, and a headless-Chromium render. That is a production run
+someone sits through, not a build step. `example/.hve/brief-state.json` is the consent record that
+makes the claim checkable — `validate_brief.py --project-dir example status` reports it complete,
+confirmed and unstale.
 
 ▶ **[Download the 53-second v0.1.0 reference render](https://github.com/nebrass/hve-video-director/releases/download/v0.1.0/hve-video-director-example-v0.1.0.mp4)**
 (1920×1080, H.264 + AAC, 18 MB) — a promo for [blog.nebrass.fr](https://blog.nebrass.fr) using four

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ layer had to decide how to show an *idea*.
 | Hero budget | `visual_ceiling: derived` imposed no ceiling, and derivation still spent Three.js on exactly **one** frame of eight |
 
 The source artifacts are committed (`context.md`, `storyboard.md`, `DESIGN.md`, `scenes/*.html`,
-`ledger.json`, `index.html`); media is gitignored and regenerable, and the MP4 ships as an asset on
-the v0.2.0 release.
+`ledger.json`, `index.html`). Media is **not** committed — it is regenerable from what is here, and
+a rendered MP4 is attached to a Release when one is produced. No render of this build is published
+yet; the downloads below are the older v0.1.0 films.
 
 It is a **record, not a fixture**, and it is only worth anything while every byte is what the
 pipeline actually emitted. Producing one is a **human-in-the-loop run**: every phase ends at a

--- a/README.md
+++ b/README.md
@@ -15,10 +15,21 @@ pipeline remains unverified.
 
 ## Reference build
 
-**[`example/`](example/) is the committed reference build**, regenerated in v0.2.0 against the
-HyperFrames-first pipeline: `context.md`, `storyboard.md` in the official shape, `DESIGN.md`, eight
-scenes, the seam `ledger.json`, and the root `index.html`. Media is gitignored; the MP4 ships as a
-Release asset.
+**[`example/`](example/) is the committed reference build** — regenerated in v0.2.0 against the
+HyperFrames-first pipeline. It is a **60-second promo the skill made about itself**, which makes it
+the honest test: with `product_surface: none` there was no product UI to lean on, so the reasoning
+layer had to decide how to show an *idea*.
+
+| | |
+|---|---|
+| Frames | 8, in the official storyboard shape, each carrying its director keys |
+| Identity | `design-system: stripe`, dark theme, 1920×1080 |
+| Seams | 4 z-axis rows in [`ledger.json`](example/ledger.json), stamped and numerically verified |
+| Hero budget | `visual_ceiling: derived` imposed no ceiling, and derivation still spent Three.js on exactly **one** frame of eight |
+
+The source artifacts are committed (`context.md`, `storyboard.md`, `DESIGN.md`, `scenes/*.html`,
+`ledger.json`, `index.html`); media is gitignored and regenerable, and the MP4 ships as an asset on
+the v0.2.0 release.
 
 It is a **record, not a fixture**, and it is only worth anything while every byte is what the
 pipeline actually emitted. Producing one is a **human-in-the-loop run**: every phase ends at a
@@ -28,22 +39,22 @@ someone sits through, not a build step. `example/.hve/brief-state.json` is the c
 makes the claim checkable — `validate_brief.py --project-dir example status` reports it complete,
 confirmed and unstale.
 
+### Earlier renders
+
+Two hosted films from the v0.1.0 era. **Neither is `example/`** — they are different projects, kept
+because they are real output, and they predate the HyperFrames rebase.
+
 ▶ **[Download the 53-second v0.1.0 reference render](https://github.com/nebrass/hve-video-director/releases/download/v0.1.0/hve-video-director-example-v0.1.0.mp4)**
 (1920×1080, H.264 + AAC, 18 MB) — a promo for [blog.nebrass.fr](https://blog.nebrass.fr) using four
-real Chrome DevTools captures as the product spine, attached to the
+real Chrome DevTools captures as the product spine, built on the vendored **Vercel** design system
+([`design-systems/vercel/DESIGN.md`](design-systems/vercel/DESIGN.md)) and attached to the
 [v0.1.0 release](https://github.com/nebrass/hve-video-director/releases/tag/v0.1.0).
 
 [![Watch the v0.1.0 launch video](https://img.youtube.com/vi/6tclnFpWRMA/maxresdefault.jpg)](https://www.youtube.com/watch?v=6tclnFpWRMA)
 
 ▶ **[Watch the 60-second v0.1.0 launch video](https://www.youtube.com/watch?v=6tclnFpWRMA)** — why
 the rename happened, why `npx skills update` cannot complete it, and the two commands that fix it.
-It was produced end-to-end by hve-video-director v0.1.0 itself, as a separate project from the
-reference build.
-
-The reference render was produced with a vendored design system (Vercel, at
-[`design-systems/vercel/DESIGN.md`](design-systems/vercel/DESIGN.md)), a Phase 3–4 HyperFrames
-composition, Phase 5 voiceover + licensed music + ffmpeg mix, and `npx hyperframes render` to MP4 at
-1920×1080, 30fps.
+Produced end-to-end by hve-video-director v0.1.0 itself, as a separate project again.
 
 ## What It Does
 


### PR DESCRIPTION
Cuts the six commits accumulated since `v0.1.0` as a **MINOR** release.

## Why a new version rather than amending v0.1.0

Amending was considered and rejected:

- **`v0.1.0` is published and in use** — 9 days old, and its `hve-video-director-example-v0.1.0.mp4` asset already has **11 downloads**. Moving the tag would change what that version means for anyone installing it later, under the same name.
- **The delta isn't a patch to v0.1.0.** The bulk is [#34](https://github.com/nebrass/hve-video-director/pull/34), the M0–M6 ecosystem rebase — new `reasoning/`, `grammar/` and `compat/` layers, a numeric seam gate, the official storyboard shape, delegated audio. That's an architecture change, not a bug-fix roll-up, and presenting it as the release people already installed would misrepresent it.
- **The repo's own conventions.** `CHANGELOG.md` declares Keep a Changelog + SemVer, where a released version is immutable; and the pin/update policy in `compat/ecosystem.md` exists precisely so a pin resolves to one thing.

MINOR rather than PATCH because #34 adds capability and restructures the skill, while keeping generated projects resumable.

## Changes

| File | Change |
|---|---|
| `CHANGELOG.md` | `[0.2.0]` section documenting #34 (M0–M6) and #35, plus link refs |
| `.claude-plugin/plugin.json` | `0.1.0` → `0.2.0` |
| `.claude-plugin/marketplace.json` | `0.1.0` → `0.2.0` |
| `README.md` | corrects a stale claim (below) |

## The README correction

The **Reference build** section still said the committed reference project *"was removed rather than left in the tree as a misleading example"*. That stopped being true in #34, which regenerated it. On `main` today:

- `example/` is present — 19 files, 8 scenes, a seam `ledger.json`, root `index.html`
- `python3 scripts/validate_brief.py --project-dir example status` → **complete, story confirmed, audio confirmed, zero stale phases**

which is exactly what `CLAUDE.md` says `example/` should be. The section now describes what is actually in the tree, and keeps the human-in-the-loop framing (ADR-001) that makes the reference build meaningful.

## Verification

- `bash test/run.sh` — **239 tests, OK**
- Version parity across both manifests — `0.2.0` / `0.2.0`
- README claim reconciled against the tree (`example/` exists; the "removed" sentence is gone)
- CHANGELOG anchors and compare links resolve

## After merge

Tag `v0.2.0` on `main` and publish the release. `v0.1.0`, its tag and its 11-download asset are untouched.

https://claude.ai/code/session_01KA8kncvpqhQ4m4ChsLzzuF